### PR TITLE
added postCreateCommand (GDEV-300)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -62,7 +62,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [5000, 5432],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip install --user -r requirements.txt",
+	"postCreateCommand": "dev_install",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }


### PR DESCRIPTION
Title:
```
run dev_install automatically upon devcontainer start (GDEV-300)
```

Description:
```
Using the "postCreateCommand" in the .devcontainer config
to automatically run the dev_install script
```