### PR TITLE
fix badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![tests](https://github.com/ghga-de/ghga-service-chassis-lib/actions/workflows/unit_and_int_tests.yaml/badge.svg)
+\# please adapt the links following badges to the service:
+![tests](https://github.com/ghga-de/microservice-repository-template/actions/workflows/unit_and_int_tests.yaml/badge.svg)
 [![codecov](https://codecov.io/gh/ghga-de/microservice-repository-template/branch/main/graph/badge.svg?token=GYH99Y71CK)](https://codecov.io/gh/ghga-de/microservice-repository-template)
 
 


### PR DESCRIPTION
Title:
```
fix badge link for unit and int tests
```
Title:
```
The badge link for unit and int tests accidentally
pointed to the corresponding workflow in the
ghga_service_chassis_lib repo.
```