### PR TITLE
use pubsub base config (GDEV-302)

### DIFF
--- a/my_microservice/config.py
+++ b/my_microservice/config.py
@@ -19,16 +19,19 @@ from functools import lru_cache
 
 from ghga_service_chassis_lib.api import ApiConfigBase
 from ghga_service_chassis_lib.config import config_from_yaml
+from ghga_service_chassis_lib.pubsub import PubSubConfigBase
 
 from .models import SupportedLanguages
 
 
 @config_from_yaml(prefix="my-microservice")
-class Config(ApiConfigBase):
+class Config(ApiConfigBase, PubSubConfigBase):
     """Config parameters and their defaults."""
 
     # config parameter needed for the api server
-    # are inherited from ApiConfigBase
+    # are inherited from ApiConfigBase;
+    # config parameter needed for the api server
+    # are inherited from PubSubConfigBase;
 
     language: SupportedLanguages = "Croatian"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ include_package_data = True
 packages = find:
 install_requires =
     # Please adapt to the current version of the library
-    ghga-service-chassis-lib[pubsub,api]==0.3.0
+    ghga-service-chassis-lib[pubsub,api]==0.4.0
 
     # Include this package, if your microservice should communicate with an s3 instance
     # boto3==1.18.28


### PR DESCRIPTION
uses the PubSubConfigBase class from the ghga_service_chassis_lib
as base for the config class