### PR TITLE
Fix ingestion of config params for dev_launcher script

### DIFF
--- a/.devcontainer/dev_launcher
+++ b/.devcontainer/dev_launcher
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# cd into .devcontainer dir so that the config yaml
+# is considered:
+cd /workspace/.devcontainer
+
 # adapt to package name
-my-microservice --config /workspace/.devcontainer/dev_config.yaml
+my-microservice


### PR DESCRIPTION
The dev_launcher script passed the config yaml via a CLI option to the service.
This option no longer exists. Config parameters are now ingested via the
`.my_microservice.yaml` file in the `.devcontainer` dir.