### PR TITLE
show a vertical line at the intended line limit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,6 +37,9 @@
 		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
 		"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest",
 		"editor.renderWhitespace": "all",
+		"editor.rulers": [
+			88
+		],
 		"licenser.license": "AL2",
 		"licenser.author": "Universität Tübingen, DKFZ and EMBL\nfor the German Human Genome-Phenome Archive (GHGA)",
 	},


### PR DESCRIPTION
Title for squash and merge:
```
show a vertical line at the intended line limit
```

Description for squash and merge:
```
Shows a vertical line at 88 characters.
```