### PR TITLE
inherit dev deps from the ghga_service_chassis_lib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ include_package_data = True
 packages = find:
 install_requires =
     # Please adapt to the current version of the library
-    ghga-service-chassis-lib[pubsub,api]==0.4.0
+    ghga-service-chassis-lib[pubsub,api]==0.6.0
 
     # Include this package, if your microservice should communicate with an s3 instance
     # boto3==1.18.28
@@ -68,20 +68,7 @@ console_scripts =
 [options.extras_require]
 # Please adapt:
 dev =
-    pytest
-    pytest-cov
-    mypy
-    pylint
-    black
-    isort
-    bandit
-    flake8
-    pre-commit
-    requests
-    mkdocs
-    mkdocs-material
-    mkdocstrings
-    testcontainers
+    ghga-service-chassis-lib[dev]==0.6.0
 # Please adapt: Only needed if you are using alembic for database versioning (Probably for PostgreSQL)
 db_migration =
     alembic==1.6.5


### PR DESCRIPTION
Title for squash and merge:
```
inherit dev deps from the ghga_service_chassis_lib
```

Description for squash and merge:
```
Inherit dev and testing dependencies from the ghga_service_chassis_lib.
Moreover, updated the ghga_service_chassis_lib to version 0.6.0.
```

Will work once the new version of the ghga_service_chassis_lib  is released.