### PR TITLE
license checker supports year range (GDEV-447)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
-; Copyright 2021 Universität Tübingen, DKFZ and EMBL
+; Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 ; for the German Human Genome-Phenome Archive (GHGA)
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Universität Tübingen, DKFZ and EMBL
+   Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
    for the German Human Genome-Phenome Archive (GHGA)
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/__init__.py
+++ b/my_microservice/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/__main__.py
+++ b/my_microservice/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/api/__init__.py
+++ b/my_microservice/api/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/api/deps.py
+++ b/my_microservice/api/deps.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/api/main.py
+++ b/my_microservice/api/main.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/config.py
+++ b/my_microservice/config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/core/__init__.py
+++ b/my_microservice/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/core/greeting.py
+++ b/my_microservice/core/greeting.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/dao/__init__.py
+++ b/my_microservice/dao/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/dao/db.py
+++ b/my_microservice/dao/db.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/dao/db_models.py
+++ b/my_microservice/dao/db_models.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/models.py
+++ b/my_microservice/models.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/pubsub/__init__.py
+++ b/my_microservice/pubsub/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/my_microservice/pubsub/main.py
+++ b/my_microservice/pubsub/main.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/check_mandatory_and_static_files.py
+++ b/scripts/check_mandatory_and_static_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/get_config_shema_and_example.py
+++ b/scripts/get_config_shema_and_example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/get_package_name.py
+++ b/scripts/get_package_name.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -26,7 +26,7 @@ import re
 import sys
 from datetime import date
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 # root directory of the package:
 ROOT_DIR = Path(__file__).parent.parent.resolve()
@@ -96,6 +96,41 @@ MIN_YEAR = 2021
 
 # The path to the License file relative to target dir
 LICENCE_FILE = "LICENSE"
+
+
+class GlobalCopyrightNotice:
+    """
+    This is used to store the copyright notice that should be identical for all checked
+    files.
+    The text of the copyright notice is stored in the `text`
+    property. This property can only be set once.
+    The property `n_lines` gives the number of lines of the text. It is infered once
+    `text` is set.
+    """
+
+    def __init__(self):
+        self._text: Optional[str] = None
+        self._n_lines: Optional[int] = None
+
+    @property
+    def text(self) -> Optional[str]:
+        return self._text
+
+    @text.setter
+    def text(self, new_text: str):
+        if self._text is not None:
+            raise RuntimeError("You can only set the value once.")
+        self._text = new_text
+        self._n_lines = len(self._text.split("\n"))
+
+    @property
+    def n_lines(self) -> int:
+        if self._n_lines is None:
+            raise ValueError(
+                "This property is not yet available."
+                + " Please set the `text` property first."
+            )
+        return self._n_lines
 
 
 class UnexpectedBinaryFileError(RuntimeError):
@@ -223,6 +258,7 @@ def get_header(file_path: Path, comment_chars: List[str] = COMMENT_CHARS):
 def validate_year_string(year_string: str, min_year: int = MIN_YEAR) -> bool:
     """Check if the specified year string is valid.
     Returns `True` if valid or `False` otherwise."""
+
     current_year = date.today().year
 
     # If the year_string is a single number, it must be the current year:
@@ -248,6 +284,7 @@ def validate_year_string(year_string: str, min_year: int = MIN_YEAR) -> bool:
 
 def check_copyright_notice(
     copyright: str,
+    global_copyright: GlobalCopyrightNotice,
     copyright_template: str = COPYRIGHT_TEMPLATE,
     author: str = AUTHOR,
     comment_chars: List[str] = COMMENT_CHARS,
@@ -257,6 +294,11 @@ def check_copyright_notice(
 
     copyright_template (str):
         A string containing the copyright text to check against the template.
+    global_copyright (str, None):
+        If this is a string, it is checked whether the copyright notice in this file
+        contains the same year string.
+        If this is None, the variable is set to the year string present in the
+        copyright notice of this file.
     copyright_template (str, optional):
         A string containing a template for the expected license header.
         You may include "{year}" which will be replace by the current year.
@@ -267,17 +309,22 @@ def check_copyright_notice(
         header. This defaults to an auther info for GHGA.
 
     """
+    # If the global_copyright is already set, check if the current copyright is
+    # identical to it:
+    copyright_lines = copyright.split("\n")
+    if global_copyright.text is not None:
+        copyright_cleaned = "\n".join(copyright_lines[0 : global_copyright.n_lines])
+        return global_copyright.text == copyright_cleaned
+
     formatted_template = format_copyright_template(copyright_template, author=author)
     template_lines = formatted_template.split("\n")
 
-    notice_lines = copyright.split("\n")
-
     # The header should be at least as long as the template:
-    if len(notice_lines) < len(template_lines):
+    if len(copyright_lines) < len(template_lines):
         return False
 
     for idx, template_line in enumerate(template_lines):
-        header_line = notice_lines[idx]
+        header_line = copyright_lines[idx]
 
         if "{year}" in template_line:
             pattern = template_line.replace("{year}", r"(.+?)")
@@ -293,11 +340,16 @@ def check_copyright_notice(
         elif template_line != header_line:
             return False
 
+    # Take this copyright as the global_copyright from now on:
+    copyright_cleaned = "\n".join(copyright_lines[0 : len(template_line)])
+    global_copyright.text = copyright_cleaned
+
     return True
 
 
 def check_file_headers(
     target_dir: Path,
+    global_copyright: GlobalCopyrightNotice,
     copyright_template: str = COPYRIGHT_TEMPLATE,
     author: str = AUTHOR,
     exclude: List[str] = EXCLUDE,
@@ -315,6 +367,11 @@ def check_file_headers(
             A string containing a template for the expected license header.
             You may include "{year}" which will be replace by the current year.
             This defaults to the Apache 2.0 Copyright notice.
+        global_copyright (str, None):
+            If this is a string, it is checked whether the copyright notice of these
+            files contains the same year string.
+            If this is None, the variable is set to the year string present in the
+            copyright notice of these files.
         author (str, optional):
             The author that shall be included in the license header.
             It will replace any appearance of "{author}" in the license
@@ -345,6 +402,7 @@ def check_file_headers(
             header = get_header(target_file, comment_chars=comment_chars)
             if check_copyright_notice(
                 copyright=header,
+                global_copyright=global_copyright,
                 copyright_template=copyright_template,
                 author=author,
                 comment_chars=comment_chars,
@@ -362,6 +420,7 @@ def check_file_headers(
 
 def check_license_file(
     license_file: Path,
+    global_copyright: GlobalCopyrightNotice,
     copyright_template: str = COPYRIGHT_TEMPLATE,
     author: str = AUTHOR,
     comment_chars: List[str] = COMMENT_CHARS,
@@ -372,6 +431,11 @@ def check_license_file(
 
     Args:
         license_file (pathlib.Path, optional): Overwrite the default license file.
+        global_copyright (str, None):
+            If this is a string, it is checked whether the copyright notice in this file
+            contains the same year string.
+            If this is None, the variable is set to the year string present in the
+            copyright notice of this file.
         copyright_template (str, optional):
             A string of the copyright notice (usually same as license header).
             You may include "{year}" which will be replace by the current year.
@@ -398,6 +462,7 @@ def check_license_file(
 
     return check_copyright_notice(
         copyright=copyright,
+        global_copyright=global_copyright,
         copyright_template=copyright_template,
         author=author,
         comment_chars=comment_chars,
@@ -434,26 +499,32 @@ def run():
 
     print(f'Working in "{target_dir}"\n')
 
-    print("Checking license headers in files:")
-    passed_files, failed_files = check_file_headers(target_dir)
-    print(f"{len(passed_files)} files passed.")
-    print(f"{len(failed_files)} files failed" + (":" if failed_files else "."))
-    for failed_file in failed_files:
-        print(f'  - "{failed_file.relative_to(target_dir)}"')
-
-    print("")
+    global_copyright = GlobalCopyrightNotice()
 
     if args.no_license_file_check:
         license_file_valid = True
     else:
         license_file = Path(target_dir / LICENCE_FILE)
         print(f'Checking if LICENSE file is up to date: "{license_file}"')
-        license_file_valid = check_license_file(license_file)
+        license_file_valid = check_license_file(
+            license_file, global_copyright=global_copyright
+        )
         print(
             "Copyright notice in license file is "
             + ("" if license_file_valid else "not ")
             + "up to date.\n"
         )
+
+    print("Checking license headers in files:")
+    passed_files, failed_files = check_file_headers(
+        target_dir, global_copyright=global_copyright
+    )
+    print(f"{len(passed_files)} files passed.")
+    print(f"{len(failed_files)} files failed" + (":" if failed_files else "."))
+    for failed_file in failed_files:
+        print(f'  - "{failed_file.relative_to(target_dir)}"')
+
+    print("")
 
     if failed_files or not license_file_valid:
         print("Some checks failed.")

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ import re
 import sys
 from datetime import date
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 # root directory of the package:
 ROOT_DIR = Path(__file__).parent.parent.resolve()
@@ -85,11 +85,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
+# A list of all chars that may be used to introduce a comment:
+COMMENT_CHARS = ["#"]
+
 AUTHOR = """Universität Tübingen, DKFZ and EMBL
 for the German Human Genome-Phenome Archive (GHGA)"""
 
 # The path to the License file relative to target dir
 LICENCE_FILE = "LICENSE"
+
+
+class UnexpectedBinaryFileError(RuntimeError):
+    """Thrown when trying to read a binary file."""
+
+    def __init__(self, file_path: Union[str, Path]):
+        message = f"The file could not be read because it is binary: {str(file_path)}"
+        super().__init__(message)
 
 
 def get_target_files(  # pylint: disable=dangerous-default-value
@@ -131,48 +142,194 @@ def get_target_files(  # pylint: disable=dangerous-default-value
     return target_files
 
 
-def normalized_text(text: str) -> str:
+def normalized_line(line: str, chars_to_trim: List[str] = COMMENT_CHARS) -> str:
+    norm_line = line.strip()
+
+    for char in chars_to_trim:
+        norm_line = norm_line.strip(char)
+
+    return norm_line.strip("\n").strip("\t").strip()
+
+
+def normalized_text(text: str, chars_to_trim: List[str] = COMMENT_CHARS) -> str:
     "Normalize a license header text."
-    return "\n".join(
-        [
-            line.strip("#").strip()
-            for line in text.split("\n")
-            if not (  # exclude shebang and empty lines
-                line.startswith("#!") or line.strip("#").strip() == ""
-            )
-        ]
-    ).strip("\n")
+    lines = text.split("\n")
+
+    norm_lines: List[str] = []
+
+    for line in lines:
+        stripped_line = line.strip()
+        # exclude shebang:
+        if stripped_line.startswith("#!"):
+            continue
+
+        norm_line = normalized_line(stripped_line)
+
+        # exclude empty lines:
+        if norm_line == "":
+            continue
+
+        norm_lines.append(norm_line)
+
+    return "\n".join(norm_lines).strip("\n")
 
 
 def format_license_header_template(license_header_template: str, author: str) -> str:
-    """Formats license header by inserting the current year and the
-    specified author for every occurence of "{year}" and "{author}",
-    respectively, in the header template.
+    """Formats license header by inserting the specified author for every occurence of
+    "{author}" in the header template.
     """
+    return normalized_text(license_header_template.replace("{author}", author))
+
+
+def is_commented_line(line: str, comment_chars: List[str] = COMMENT_CHARS) -> bool:
+    """Checks whether a line is a comment."""
+    line_stripped = line.strip()
+    for commment_char in comment_chars:
+        if line_stripped.startswith(commment_char):
+            return True
+
+    return False
+
+
+def is_empty_line(line: str) -> bool:
+    """Checks whether a line is empty."""
+    return line.strip("\n").strip("\t").strip() == ""
+
+
+def get_header_lines(file_path: Path, comment_chars: List[str] = COMMENT_CHARS):
+    """Extracts the header from a file and normalizes it."""
+    header_lines: List[str] = []
+
+    try:
+        with open(file_path, "r") as file:
+            for line in file:
+                if is_commented_line(
+                    line, comment_chars=comment_chars
+                ) or is_empty_line(line):
+                    header_lines.append(line)
+                else:
+                    break
+    except UnicodeDecodeError as error:
+        raise UnexpectedBinaryFileError(file_path=file_path) from error
+
+    # normalize the lines:
+    header = "".join(header_lines)
+    norm_header = normalized_text(header, chars_to_trim=comment_chars)
+    norm_header_lines = norm_header.split("\n")
+
+    return norm_header_lines
+
+
+def validate_year_string(year_string: str) -> bool:
+    """Check if the specified year string is valid.
+    Returns `True` if valid or `False` otherwise."""
     current_year = str(date.today().year)
-    return normalized_text(
-        license_header_template.replace("{year}", current_year).replace(
-            "{author}", author
-        )
-    )
+
+    # If the year_string is a single number, it must be the current year:
+    if year_string.isnumeric():
+        return year_string == current_year
+
+    # Otherwise, a range (e.g. 2021 - 2022) is expected:
+    match = re.match("(\d+) - (\d+)", year_string)
+
+    if not match:
+        return False
+
+    year_1 = match.group(1)
+    year_2 = match.group(2)
+
+    # year_2 must be larger that year_1
+    if int(year_2) <= int(year_1):
+        return False
+
+    # year_2 must be equal to the current year:
+    return year_2 == current_year
 
 
-def check_file_headers(  # pylint: disable=dangerous-default-value
-    target_dir: Path,
-    license_header: str = LICENSE_HEADER,
+def check_file_header(  # pylint: disable=dangerous-default-value
+    file_path: Path,
+    license_header_template: str = LICENSE_HEADER,
     author: str = AUTHOR,
     exclude: List[str] = EXCLUDE,
     exclude_endings: List[str] = EXCLUDE_ENDINGS,
     exclude_pattern: List[str] = EXCLUDE_PATTERN,
+    comment_chars: List[str] = COMMENT_CHARS,
+) -> bool:
+    """Check files for presence of a license header and verify that
+    the copyright notice is up to date (correct year).
+
+    Args:
+        file_path (pathlib.Path): The path to the target file.
+        license_header_template (str, optional):
+            A string containing a template for the expected license header.
+            You may include "{year}" which will be replace by the current year.
+            This defaults to the Apache 2.0 Copyright notice.
+        author (str, optional):
+            The author that shall be included in the license header.
+            It will replace any appearance of "{author}" in the license
+            header. This defaults to an auther info for GHGA.
+        exclude (List[str], optional):
+            Overwrite default list of file/dir paths relative to
+            the target dir that shall be excluded.
+        exclude_endings (List[str], optional):
+            Overwrite default list of file endings that shall
+            be excluded.
+        exclude_pattern (List[str], optional):
+            Overwrite default list of regex patterns match file path
+            for exclusion.
+
+    Returns:
+        `True` - If file header valid.
+        `False` - If file header invalid
+    """
+    formatted_template = format_license_header_template(
+        license_header_template, author=author
+    )
+    template_lines = formatted_template.split("\n")
+
+    header_lines = get_header_lines(file_path, comment_chars=comment_chars)
+
+    # The header should be at least as long as the template:
+    if len(header_lines) < len(template_lines):
+        return False
+
+    for idx, template_line in enumerate(template_lines):
+        header_line = header_lines[idx]
+
+        if "{year}" in template_line:
+            pattern = template_line.replace("{year}", r"(.+?)")
+            match = re.match(pattern, header_line)
+
+            if not match:
+                return False
+
+            year_string = match.group(1)
+            if not validate_year_string(year_string):
+                return False
+
+        elif template_line != header_line:
+            return False
+
+    return True
+
+
+def check_file_headers(  # pylint: disable=dangerous-default-value
+    target_dir: Path,
+    license_header_template: str = LICENSE_HEADER,
+    author: str = AUTHOR,
+    exclude: List[str] = EXCLUDE,
+    exclude_endings: List[str] = EXCLUDE_ENDINGS,
+    exclude_pattern: List[str] = EXCLUDE_PATTERN,
+    comment_chars: List[str] = COMMENT_CHARS,
 ) -> Tuple[List[Path], List[Path]]:
     """Check files for presence of a license header and verify that
     the copyright notice is up to date (correct year).
 
     Args:
         target_dir (pathlib.Path): The target dir to search.
-        license_header (str, optional):
-            A string of the license header. You may include
-            "{year}" which will be replace by the current year.
+        license_header_template (str, optional):
+            A string containing a template for the expected license header.
+            You may include "{year}" which will be replace by the current year.
             This defaults to the Apache 2.0 Copyright notice.
         author (str, optional):
             The author that shall be included in the license header.
@@ -195,31 +352,24 @@ def check_file_headers(  # pylint: disable=dangerous-default-value
         exclude_pattern=exclude_pattern,
     )
 
-    # insert current year and author into license header:
-    license_header_formatted = format_license_header_template(license_header, author)
-
     # check if license header present in file:
     passed_files: List[Path] = []
     failed_files: List[Path] = []
 
-    n_header_lines = len(license_header_formatted.split("\n"))
-
     for target_file in target_files:
-        # read in file
-        with open(target_dir / target_file, "r") as file_:
-            file_content = normalized_text(file_.read())
-        # check whether file has enough lines
-        file_lines = file_content.split("\n")
-        n_file_lines = len(file_lines)
-        if n_file_lines < n_header_lines:
-            failed_files.append(target_file)
-            continue
-        # check whether first lines match the header:
-        header_expected = "\n".join(file_lines[0:n_header_lines])
-        if header_expected == license_header_formatted:
-            passed_files.append(target_file)
-        else:
-            failed_files.append(target_file)
+        try:
+            if check_file_header(
+                target_file,
+                license_header_template=license_header_template,
+                author=author,
+                comment_chars=comment_chars,
+            ):
+                passed_files.append(target_file)
+            else:
+                failed_files.append(target_file)
+        except UnexpectedBinaryFileError:
+            # This file is a binary and is therefor skipped.
+            pass
 
     return (passed_files, failed_files)
 

--- a/scripts/openapi_from_app.py
+++ b/scripts/openapi_from_app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/update_static_files.py
+++ b/scripts/update_static_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/fixtures/utils.py
+++ b/tests/integration/fixtures/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/fixtures/__init__.py
+++ b/tests/unit/fixtures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/fixtures/utils.py
+++ b/tests/unit/fixtures/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_dummy.py
+++ b/tests/unit/test_dummy.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Title for squash and merge:
```
license checker supports year range (GDEV-447)
```

Description for squash and merge:
```
Adapt the license checker to check for the following conditions:
- The copyright claim can be a single year, or a range of years (e.g. 2021 - 2023)
- If it is a single year, this year is treated as both, the first year and the last year
- The first year of the copyright claim is 2021 or higher
- The last year of the copyright claim is the current year or lower
- The copyright notice is identical in all files.

Moreover, updated the license headers of all files accordingly.
```