### PR TITLE
make config generation script agnostic (GDEV-477)

### DIFF
--- a/.mandatory_files
+++ b/.mandatory_files
@@ -21,7 +21,6 @@ docs/README.md
 example_data
 
 scripts
-scripts/get_config_schema_and_example.py
 
 tests/fixtures/__init__.py
 tests/integration/fixtures/__init__.py

--- a/.static_files
+++ b/.static_files
@@ -13,6 +13,7 @@
 scripts/update_static_files.py
 scripts/license_checker.py
 scripts/get_package_name.py
+scripts/get_config_schema_and_example.py
 scripts/check_mandatory_and_static_files.py
 scripts/README.md
 

--- a/scripts/get_config_schema_and_example.py
+++ b/scripts/get_config_schema_and_example.py
@@ -18,12 +18,21 @@
 """Generate a JSON schema from the service's Config class.
 """
 
+import importlib
 from pathlib import Path
+from typing import Any, Type
 
 import yaml
+from pydantic import BaseSettings
 from typer import Typer
 
-from my_microservice.config import Config
+from scripts.get_package_name import get_package_name
+
+# Dynamically import the Config class from the current service:
+# (This makes the script service repo agnostic.)
+package_name = get_package_name()
+config_module: Any = importlib.import_module(f"{package_name}.config")
+Config: Type[BaseSettings] = config_module.Config
 
 HERE = Path(__file__).parent.resolve()
 DEV_CONFIG_YAML = HERE.parent.resolve() / ".devcontainer" / ".dev_config.yaml"

--- a/scripts/get_package_name.py
+++ b/scripts/get_package_name.py
@@ -24,7 +24,7 @@ SETUP_CFG_PATH = REPO_ROOT_DIR / "setup.cfg"
 NAME_PREFIX = "name = "
 
 
-def run():
+def get_package_name() -> str:
     """Extracts the package name"""
 
     with open(SETUP_CFG_PATH, "r", encoding="utf8") as setup_cfg:
@@ -32,8 +32,14 @@ def run():
             line_stripped = line.strip()
             if line_stripped.startswith(NAME_PREFIX):
                 package_name = line_stripped[len(NAME_PREFIX) :]
-                print(package_name)
-                return
+                return package_name
+        raise RuntimeError("Could not find package name.")
+
+
+def run():
+    """Run this script."""
+    package_name = get_package_name()
+    print(package_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Title for squash and merge:
```
make config generation script agnostic (GDEV-477)
```

Description for squash and merge:
```
The script now infer the package name via the `get_package_name.py` script
and dynamically imports the Config class from there.
```