### PR TITLE
fix automatic license inserter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,8 +42,8 @@
 		"editor.rulers": [
 			88
 		],
-		"licenser.license": "AL2",
-		"licenser.author": "Universität Tübingen, DKFZ and EMBL\nfor the German Human Genome-Phenome Archive (GHGA)",
+		"licenser.license": "Custom",
+		"licenser.customHeaderFile": "/workspace/.devcontainer/license_header.txt"
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [

--- a/.devcontainer/license_header.txt
+++ b/.devcontainer/license_header.txt
@@ -1,0 +1,14 @@
+Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+for the German Human Genome-Phenome Archive (GHGA)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/.mandatory_files
+++ b/.mandatory_files
@@ -10,6 +10,7 @@
 .devcontainer/devcontainer.json
 .devcontainer/docker-compose.yml
 .devcontainer/Dockerfile
+.devcontainer/license_header.txt
 
 .github/workflows/dev_cd.yaml
 .github/workflows/unit_and_int_tests.yaml

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -31,6 +31,9 @@ from typing import List, Optional, Tuple, Union
 # root directory of the package:
 ROOT_DIR = Path(__file__).parent.parent.resolve()
 
+# file containing the default global copyright notice:
+GLOBAL_COPYRIGHT_FILE_PATH = ROOT_DIR / ".devcontainer" / "license_header.txt"
+
 # exlude files and dirs from license header check:
 EXCLUDE = [
     ".devcontainer",
@@ -501,6 +504,10 @@ def run():
     print(f'Working in "{target_dir}"\n')
 
     global_copyright = GlobalCopyrightNotice()
+
+    # get global copyright from .devcontainer/license_header.txt file:
+    with open(GLOBAL_COPYRIGHT_FILE_PATH, "r") as global_copyright_file:
+        global_copyright.text = normalized_text(global_copyright_file.read())
 
     if args.no_license_file_check:
         license_file_valid = True


### PR DESCRIPTION
Title for squash and merge:
```
fix automatic license inserter
```

Description for squash and merge:
```
Use custom file header from file for automatically inserting license headers into
empty files.
This custom file header file also becomes the source of truth for the license checker
script.
```