### PR TITLE
Add missing openapi_from_app.py script to .static_files

### DIFF
--- a/.static_files
+++ b/.static_files
@@ -16,6 +16,7 @@ scripts/license_checker.py
 scripts/get_package_name.py
 scripts/get_config_schema_and_example.py
 scripts/check_mandatory_and_static_files.py
+scripts/openapi_from_app.py
 scripts/README.md
 
 .github/workflows/check_pr_target.yaml


### PR DESCRIPTION
Title for squash and merge:
```
Add missing openapi_from_app.py script to static file list
```

@KerstenBreuer Would be good to have `openapi_from_app.py` be part of `.static_files`. Not sure if the omission was intentional or by mistake.