### PR TITLE
Add an init script that guides the user through all necessary template adaptions

### DIFF
--- a/.devcontainer/dev_launcher
+++ b/.devcontainer/dev_launcher
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# adapt to package name
 my-microservice

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         # [Choice] Install Node.js
         INSTALL_NODE: "true"
         NODE_VERSION: "lts/*"
-        # Please adapt to package name:
         PACKAGE_NAME: "my_microservice"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000
@@ -31,7 +30,6 @@ services:
 
     # define environment variables
     environment:
-      # Please adapt to package name:
       MY_MICROSERVICE_CONFIG_YAML: /workspace/.devcontainer/.dev_config.yaml
       # Used by db migration:
       DB_URL: postgresql://postgres:postgres@postgresql/postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,4 @@ USER appuser
 
 ENV PYTHONUNBUFFERED=1
 
-# Please adapt to package name:
 ENTRYPOINT ["my-microservice"]

--- a/README.md
+++ b/README.md
@@ -1,39 +1,6 @@
-
-
-
-# Microservice Repository Template
-
-This repo is a template for creating a new microservice.
-
-The directories, files, and their structure herein are recommendations
-from the GHGA Dev Team.
-
-## Naming Conventions
-The github repository contains only lowercase letters, numbers, and hyphens "-",
-e.g.: `my-microservice`
-
-The python package (and thus the source repository) contains underscores "_"
-instead of hyphens, e.g.: `my_microservice`
-
-The command-line script that is used to run the service, the docker repository
-(published to docker hub), and the helm chart (not part of this repository) use the
-same pattern as the repository name, e.g.: `my-microservice`
-## Adapt to your service
-This is just a template and needs some adaption to your specific use case.
-
-Please search for **"please adapt"** comments. They will indicate all locations
-that need modification. Once the adaptions are in place, please remove these #
-comments.
-
-The following should serve as a template for the final repo's README,
-please adapt it accordingly (e.g. replace all occurences of `my-microservice` or `my_microservice` with the final package name and don't forget to adapt the links):
-
----
-
-**\# please adapt the links of following badges:**
 ![tests](https://github.com/ghga-de/my-microservice/actions/workflows/unit_and_int_tests.yaml/badge.svg)
 [![codecov](https://codecov.io/gh/ghga-de/my-microservice/branch/main/graph/badge.svg?token=GYH99Y71CK)](https://codecov.io/gh/ghga-de/my-microservice)
-# My-Microservice
+# My Microservice
 
 A description explaining the use case of this service.
 

--- a/my_microservice/__init__.py
+++ b/my_microservice/__init__.py
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Short description of package"""  # Please adapt to package
+"""My microservice description"""
 
 __version__ = "0.1.0"

--- a/my_microservice/__main__.py
+++ b/my_microservice/__main__.py
@@ -23,7 +23,6 @@ from .config import CONFIG, Config
 
 def run(config: Config = CONFIG):
     """Run the service"""
-    # Please adapt to package name
     run_server(app="my_microservice.__main__:app", config=config)
 
 

--- a/my_microservice/config.py
+++ b/my_microservice/config.py
@@ -24,12 +24,11 @@ from ghga_service_chassis_lib.s3 import S3ConfigBase
 from .models import SupportedLanguages
 
 
-# Please adapt config prefix and remove unnecessary config bases:
 @config_from_yaml(prefix="my_microservice")
 class Config(ApiConfigBase, PubSubConfigBase, PostgresqlConfigBase, S3ConfigBase):
     """Config parameters and their defaults."""
 
-    service_name: str = "my_microservice"  # Please adapt
+    service_name: str = "my_microservice"
     language: SupportedLanguages = "Croatian"
 
 

--- a/scripts/openapi_from_app.py
+++ b/scripts/openapi_from_app.py
@@ -26,7 +26,6 @@ import sys
 
 import yaml
 
-# Please adapt to package name:
 from my_microservice.api.main import app
 
 # get openapi spec as dict:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 [metadata]
-# Please adapt to package name:
 name = my_microservice
 version = attr: my_microservice.__version__
 description = My-Microservice - a short description
@@ -36,21 +35,17 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    # Please adapt to the current version of the library
-    # and remove the unneeded extras:
     ghga-service-chassis-lib[api,pubsub,mongo_connect,object_storage_dao,s3,postgresql]==0.9.0
 
 
 python_requires = >= 3.9
 
 [options.entry_points]
-# Please adapt to package name:
 console_scripts =
     my-microservice = my_microservice.__main__:run
 
 [options.extras_require]
 dev =
-    # Please adapt to the current version of the library
     ghga-service-chassis-lib[dev]==0.9.0
 
 # Please adapt: Only needed if you are using alembic for database versioning (Probably for PostgreSQL)

--- a/template/init
+++ b/template/init
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################################################
+# Function Definitions
+################################################################################
+
+read_parameter() { # <desc> <override_value> <default>
+  # Reads and prints a parameter from the command line, displaying <desc> at
+  # the user prompt. <default> is displayed to the user as the default value
+  # and used if no value is provided. If <override_value> is not empty, no user
+  # interaction takes place and <override_value> is printed.
+  if [ "$2" == "" ]; then
+    read -p "$1 [$3]: " value
+    echo "${value:-"$3"}"
+  else
+    echo "$2"
+  fi
+}
+
+sed_all() { # <sed expression>
+  # Execute sed expression on all files except below .git and template
+  find . -not -path './.git*' -and -not -path './template/*' -type f -exec sed -i '' -e "$1" {} \;
+}
+
+################################################################################
+# Pre-User-Input
+################################################################################
+
+# Infer default chassis lib version and extras from setup.cfg
+if [ -e "setup.cfg" ]; then
+  chassis_lib_version_default="$(egrep --color -m1 'ghga-service-chassis-lib\[[^]]*\]==' setup.cfg | sed -e 's/^.*]==\([[:digit:].]*\).*$/\1/')"
+  chassis_lib_extras_default="$(egrep --color -m1 'ghga-service-chassis-lib\[[^]]*\]==' setup.cfg | sed -e 's/^.*ghga-service-chassis-lib\[\([^]]*\)\].*$/\1/')"
+else
+  echo "setup.cfg not found. Are you at the root of the template repository?" >&2
+  exit 1
+fi
+
+# Infer default chassis lib extras
+
+################################################################################
+# Read user input
+################################################################################
+
+# Read user input
+title="$(read_parameter "Title of the microservice" "$MS_TEMPLATE_TITLE" "My Microservice")"
+desc="$(read_parameter "Description of the microservice" "$MS_TEMPLATE_DESC" "A microservice that does great things")"
+name="$(read_parameter "Name of the microservice package" "$MS_TEMPLATE_NAME" "$(echo $title | tr '[:upper:]' '[:lower:]' | sed 's/[ _]/-/g')")"
+chassis_lib_version="$(read_parameter "GHGA chassis lib version" "$MS_TEMPLATE_CHASSIS_LIB_VERSION" "$chassis_lib_version_default")"
+chassis_lib_extras="$(read_parameter "GHGA chassis lib extras" "$MS_TEMPLATE_CHASSIS_LIB_EXTRAS" "$chassis_lib_extras_default")"
+
+# Generate additional parameters
+name_snake_lower="$(echo "$name" | sed 's/-/_/g')"
+name_snake_upper="$(echo "$name_snake_lower" | tr '[:lower:]' '[:upper:]')"
+
+################################################################################
+# Patch files
+################################################################################
+
+sed_all "s/My Microservice/$title/g"
+sed_all "s/my-microservice/$name/g"
+sed_all "s/my_microservice/$name_snake_lower/g"
+sed_all "s/MY_MICROSERVICE/$name_snake_upper/g"
+sed_all "s/My microservice description/$desc/g"
+sed -i '' -e 's/\(ghga-service-chassis-lib.*\)=='"$chassis_lib_version_default"'/\1=='"$chassis_lib_version"/g setup.cfg
+sed -i '' -e "s/ghga-service-chassis-lib\[$chassis_lib_extras_default\]/ghga-service-chassis-lib\[$chassis_lib_extras\]/g" setup.cfg

--- a/template/init
+++ b/template/init
@@ -77,3 +77,9 @@ sed_all "s/MY_MICROSERVICE/$name_snake_upper/g"
 sed_all "s/My microservice description/$desc/g"
 sed -i '' -e 's/\(ghga-service-chassis-lib.*\)=='"$chassis_lib_version_default"'/\1=='"$chassis_lib_version"/g setup.cfg
 sed -i '' -e "s/ghga-service-chassis-lib\[$chassis_lib_extras_default\]/ghga-service-chassis-lib\[$chassis_lib_extras\]/g" setup.cfg
+
+################################################################################
+# Rename module folder
+################################################################################
+
+mv my_microservice/ "$name_snake_lower"/


### PR DESCRIPTION
First draft of template init script as an alternative to a cookiecutter template.

## Workflow

1. Create `new-repository` from `microservice-repository-template`
1. Clone `new-repository`
1. From `new-repository` root, execute `template/init`


## Features

* Reads some defaults (chassis-lib version and extras) directly from the template
* Values can be preset via environment variables
* Auto-infers values from project name

## Caveats

* Vulnerable to "sed injections"
* Makes some structural assumptions (e.g. first mention of `ghga-service-chassis-lib` is the production one)

## TODOs

* [x] Rename package folder
* [ ] Templatize Config base classes
* [ ] Add feature for blocks to be conditionally included