### PR TITLE
Add arm64/v8 Docker builds

### DIFF
--- a/.github/workflows/dev_cd.yaml
+++ b/.github/workflows/dev_cd.yaml
@@ -66,6 +66,7 @@ jobs:
   #       id: docker_build
   #       with:
   #         push: true
+  #         platforms: linux/amd64,linux/arm64/v8
   #         tags: "ghga/${{ github.event.repository.name }}:${{ needs.get_commit_version.outputs.version }},ghga/${{ github.event.repository.name }}:${{ needs.get_commit_version.outputs.branch }}"
   #     - name: Image digest
   #       run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
The patch would enable arm64 builds to be built and pushed to Docker Hub. Mostly for developers working on ARM not having to run Docker with amd64 emulation. Would require some follow-up PRs on individual repos.