### PR TITLE
avoid port collisions (GDEV-450)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -60,14 +60,12 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management
-    ports:
-      - 5672:5672
-      - 15672:15672
+    # useful ports:
+      # 5672 - broker
+      # 15672 - dashboard
 
   localstack:
     image: localstack/localstack
-    ports:
-      - "4566:4566"
     environment:
       SERVICES: s3
       DEFAULT_REGION: eu-west-1
@@ -83,6 +81,7 @@ services:
         target: /tmp/localstack
         volume:
           nocopy: true
+    # useful ports: 4566 - AWS API
 
 volumes:
   postgres_fs: {}


### PR DESCRIPTION
Title for squash and merge:
```
avoid port collisions (GDEV-450)
```

Description for squash and merge:
```
When running the .devcontainer environments of multiple service repositories using vscode
in parallel, port conflicts often occured.
This PR solves the problem by removing the explicit port bindings from docker compose.
```