### PR TITLE
ingore unnecessary-pass in pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -79,7 +79,7 @@ disable=
       super-init-not-called, # disabled because it falsly triggers when inheriting from
                               # a typing.Protocol (which should not come with an
                               # implementation for __init__)
-      
+
       unnecessary-pass # often thrown in non-suitable places
                        # (e.g. defining custom exception classes)
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -76,9 +76,12 @@ disable=
 
       unnecessary-ellipsis, # often used for interfaces/protocols
 
-      super-init-not-called # disabled because it falsly triggers when inheriting from
+      super-init-not-called, # disabled because it falsly triggers when inheriting from
                               # a typing.Protocol (which should not come with an
                               # implementation for __init__)
+      
+      unnecessary-pass # often thrown in non-suitable places
+                       # (e.g. defining custom exception classes)
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Title for squash and merge:
```
ingore unnecessary-pass in pylintrc
```

Description:
```
Because that caused problems e.g. when defining custom
exception classes by subclassing from building base exceptions.
```