### PR TITLE
re-introduce pass and __init__ checks (pylint) (#83)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -76,13 +76,6 @@ disable=
 
       unnecessary-ellipsis, # often used for interfaces/protocols
 
-      super-init-not-called, # disabled because it falsly triggers when inheriting from
-                              # a typing.Protocol (which should not come with an
-                              # implementation for __init__)
-
-      unnecessary-pass # often thrown in non-suitable places
-                       # (e.g. defining custom exception classes)
-
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where


### PR DESCRIPTION
Previously, we have disabled pylint checks, however, we found solutions
to avoid the problems criticized by pylint.