### PR TITLE
trigger dev CD from main instead of dev (GDEV-790)

### DIFF
--- a/.github/workflows/dev_cd.yaml
+++ b/.github/workflows/dev_cd.yaml
@@ -3,80 +3,83 @@ name: Dev CD
 on:
   push:
     branches:
-      - "dev"
+      - "main"
       # you may add other branches to
       # activate deployment for them, too.
 
 jobs:
-  # Please adapt to package
-  # Please remove this dummy job and
-  # uncomment the sections that follows to enable this workflow.
-  dummy_job:
+  get_commit_version:
     runs-on: ubuntu-latest
+    outputs:
+      # export to be used in other jobs
+      version: ${{ steps.get_commit_version.outputs.version }}
+      branch: ${{ steps.get_commit_version.outputs.branch }}
     steps:
-      - id: dummy_job
-        run: echo "this is a dummy job"
-  # get_commit_version:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     # export to be used in other jobs
-  #     version: ${{ steps.get_commit_version.outputs.version }}
-  #     branch: ${{ steps.get_commit_version.outputs.branch }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       name: Check out code
-  #       with:
-  #         # fetch the entire history
-  #         fetch-depth: 0
-  #     - id: get_commit_version
-  #       name: get commit version
-  #       run: |
-  #         BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-  #         if git describe --tags
-  #         then
-  #           VERSION="$(git describe --tags)-${BRANCH}"
-  #         else
-  #           # fallback if no tag set yet:
-  #           COMMIT_HASH="$(git rev-parse --short HEAD)"
-  #           COMMIT_NUMBER="$(git rev-list --count HEAD)"
-  #           VERSION="0.0.0-${COMMIT_NUMBER}-${COMMIT_HASH}-${BRANCH}"
-  #         fi
-  #         # set as output:
-  #         echo "commit version: ${BRANCH}"
-  #         echo "commit version: ${VERSION}"
-  #         echo "::set-output name=version::${VERSION}"
-  #         echo "::set-output name=branch::${BRANCH}"
-  # push_to_docker_hub:
-  #   runs-on: ubuntu-latest
-  #   needs: get_commit_version
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       name: Check out code
-  #     - uses: docker/setup-qemu-action@v1
-  #       name: Set up QEMU
-  #     - uses: docker/setup-buildx-action@v1
-  #       name: Set up Docker Buildx
-  #     - uses: docker/login-action@v1
-  #       name: Login to DockerHub
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
-  #     - uses: docker/build-push-action@v2
-  #       name: Build and push
-  #       id: docker_build
-  #       with:
-  #         push: true
-  #         platforms: linux/amd64,linux/arm64/v8
-  #         tags: "ghga/${{ github.event.repository.name }}:${{ needs.get_commit_version.outputs.version }},ghga/${{ github.event.repository.name }}:${{ needs.get_commit_version.outputs.branch }}"
-  #     - name: Image digest
-  #       run: echo ${{ steps.docker_build.outputs.digest }}
+      - uses: actions/checkout@v2
+        name: Check out code
+        with:
+          # fetch the entire history
+          fetch-depth: 0
+
+      - id: get_commit_version
+        name: get commit version
+        run: |
+          BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+          if git describe --tags
+          then
+            VERSION="$(git describe --tags)-${BRANCH}"
+          else
+            # fallback if no tag set yet:
+            COMMIT_HASH="$(git rev-parse --short HEAD)"
+            COMMIT_NUMBER="$(git rev-list --count HEAD)"
+            VERSION="0.0.0-${COMMIT_NUMBER}-${COMMIT_HASH}-${BRANCH}"
+          fi
+          # set as output:
+          echo "commit version: ${BRANCH}"
+          echo "commit version: ${VERSION}"
+          echo "::set-output name=version::${VERSION}"
+          echo "::set-output name=branch::${BRANCH}"
+
+  push_to_docker_hub:
+    runs-on: ubuntu-latest
+    needs: get_commit_version
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out code
+
+      - uses: docker/setup-qemu-action@v1
+        name: Set up QEMU
+
+      - uses: docker/setup-buildx-action@v1
+        name: Set up Docker Buildx
+
+      - uses: docker/login-action@v1
+        name: Login to DockerHub
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v2
+        name: Build and push
+        id: docker_build
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64/v8
+          tags: "ghga/${{ github.event.repository.name }}:${{ needs.get_commit_version.outputs.version }},ghga/${{ github.event.repository.name }}:${{ needs.get_commit_version.outputs.branch }}"
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  ## Please uncomment and adapt the DEPLOYMENT_CONFIG_REPO to trigger automatic
+  ## updates of helm charts:
+
   # update_deployment_repo:
   #   runs-on: ubuntu-latest
   #   needs:
   #     - get_commit_version
   #     - push_to_docker_hub
   #   env:
-  #     DEPLOYMENT_CONFIG_REPO: ghga-de/sandbox-deployment-configs
+  #     DEPLOYMENT_CONFIG_REPO: ghga-de/helm
   #   steps:
   #     - name: trigger update in deployment repo
   #       run: |


### PR DESCRIPTION
As discussed in the dev team meeting:

- main branch is now the source of truth for the
  deployment to the "staging" environment
- prepare for retiring of the dev branch
- not part of this PR: CD pipeline for deploying to production
  (will be added once needed)

Will delete dev branch once merged.