### PR TITLE
Improve mypy configuration for pre-commit (GDEV-807)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -9,3 +9,4 @@ exclude = (?x)(
 warn_redundant_casts = True
 warn_unused_ignores = True
 check_untyped_defs = True
+no_site_packages = False

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     rev: v0.942
     hooks:
       - id: mypy
-        args: [--python-executable, /usr/local/bin/python]
+        args: [--no-warn-unused-ignores]
   - repo: https://github.com/PyCQA/pylint
     rev: v2.13.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,11 +44,12 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
+        args: [--profile, black]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.942
     hooks:
       - id: mypy
+        args: [--python-executable, /usr/local/bin/python]
   - repo: https://github.com/PyCQA/pylint
     rev: v2.13.3
     hooks:


### PR DESCRIPTION
When we run mypy via pre-commit, standalone in Docker or via GitHub action, we always use the same configuration `.mypy.ini`. 

This is generally a good idea. However, mypy can still give a different result when run via pre-commit. This is because pre-commit uses a separate virtual env which does not have all the dependencies we may use in the code. Therefore it cannot infer certain types and will be generally more relaxed.

This is bad because it does not catch all typing errors that we can get via the checks in GitHub. It can also lead to an unsolvable dilemma: When adding a "type: ignore", pre-commit will complain ("unused ignore"), and when removing it, GitHub will complain (incompatible types, inferred from dependencies not available in the pre-commit env).

We could make running mypy in pre-commit strict by adding all dependencies. This could theoretically be done with the `additional_dependencies` option in the pre-commit configuration. However, we would need to add any possible dependencies that our microservice might use in the template, which is not reasonable. Another option would be setting the "--python-executable" in pre-commit to the same one as used standalone or in GitHub, to get the same dependencies. However, this is a bit fragile and different between local Docker and GitHub.

I currently do not see a good way to solve the problem of running mypy under pre-commit with the right dependencies, so to solve the dilemma mentioned above I have relaxed the "no unused ignore" rule from the pre-commit check.

Another solution would be to set `no_site_packages = False` to make mypy in GitHub as relaxed as in pre-commit. But this will catch less typing errors, so I want to avoid this.

Any better ideas?