### PR TITLE
Let the dev container name be the service name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/python-3-postgres
 // Update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.8, 3.7, 3.6
 {
-	"name": "Python 3 & PostgreSQL",
+	"name": "my-microservice",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",


### PR DESCRIPTION
I suggest using the service name as the name of the dev container. This name is shown as window title and thereby helps to distinguish different instances of Visual Studio Code.