### PR TITLE
fix no-commit-to-branch hook on main branch (GDEV-982)

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -19,7 +19,9 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install ".[all]"
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.0
+        env:
+          SKIP: no-commit-to-branch
       - name: black
         run: |
           black --check .


### PR DESCRIPTION
- updated the pre-commit action
- skipped no-commit-to-branch pre-commint hook when running via github actions