### PR TITLE
configure pytest to use strict asyncio_mode (GDEV-1004)

### DIFF
--- a/.static_files
+++ b/.static_files
@@ -25,6 +25,7 @@ scripts/README.md
 
 example_data/README.md
 
+pytest.ini
 .editorconfig
 .flake8
 .gitattributes

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,18 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[pytest]
+asyncio_mode = strict


### PR DESCRIPTION
Accounts for DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.