### PR TITLE
Ignore Mac and Windows desktop settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# ingore vscode settings:
+# ignore VS Code settings:
 .vscode/
 
 # desktop settings and thumbnails

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,8 @@ dmypy.json
 
 # ingore vscode settings:
 .vscode/
+
+# desktop settings and thumbnails
+.DS_Store
+desktop.ini
+thumbs.db


### PR DESCRIPTION
Avoid accidentally checking in desktop settings files from Mac or Windows.