### PR TITLE
Remove deprecated feature flag (now the default)

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -3,12 +3,8 @@
 
 cd /workspace
 
-
-# install in edit mode
-# use-feature way of installing packages
-# install with testing dependencies
+# install in edit mode with testing dependencies
 pip install \
-    --use-feature=in-tree-build \
     -e \
     ".[all]"
 


### PR DESCRIPTION
Avoid deprecation warning caused by a feature flag that has become the default in the Python 3.9 docker image we are using - see [release notes of pip 21.3](https://pip.pypa.io/en/stable/news/#v21-3).