### PR TITLE
Fix duplicate trailing line feed in config

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -19,4 +19,3 @@ s3_secret_access_key: test
 s3_session_token: null
 service_name: my_microservice
 workers: 1
-

--- a/scripts/get_config_schema_and_example.py
+++ b/scripts/get_config_schema_and_example.py
@@ -74,7 +74,7 @@ def print_schema():
 def print_example():
     """Prints an example config yaml."""
     config = get_dev_config()
-    print(yaml.dump(config.dict()))
+    print(yaml.dump(config.dict()).rstrip())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `print_example` command creates a duplicate trailing newline characters, because the YAML dump and the print function both add a newline. Therefore, the `example_config.yaml` file also needs two trailing newlines to pass the GitHub checks, because it is compared with the output of `print_example`. This problem is hard to spot, and you can't even save a YAML file with two trailing newlines in the default config of Visual Studio code.

I suggest fixing this by having the `print_example` function not output that additional empty line and removing the duplicate newline from the `example.config.yaml`. This makes the output of `print_example` also consistent with the output of `print_schema` which does not have that additional newline.