### PR TITLE
Fix for deprecated file removal

### DIFF
--- a/scripts/update_template_files.py
+++ b/scripts/update_template_files.py
@@ -146,7 +146,10 @@ def remove_files(files: list[str], check: bool = False) -> bool:
             if check:
                 print(f"  - {local_file_path}: deprecated, but exists")
             else:
-                shutil.rmtree(local_file_path)
+                if local_file_path.is_dir():
+                    shutil.rmtree(local_file_path)
+                else:
+                    local_file_path.unlink()
                 print(f"  - {local_file_path}: removed, since it is deprecated")
     return ok
 


### PR DESCRIPTION
Currently only works on directories, i.e.: `NotADirectoryError: [Errno 20] Not a directory: PosixPath('/workspace/.devcontainer/library-scripts/docker-in-docker-debian.sh')`
Added a check to correctly remove files.