### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/check_config_docs.yaml
+++ b/.github/workflows/check_config_docs.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - id: common
-        uses: ghga-de/gh-action-common@v1.0.2
+        uses: ghga-de/gh-action-common@v1.0.3
 
       - name: Check config docs
         run: |

--- a/.github/workflows/check_config_docs.yaml
+++ b/.github/workflows/check_config_docs.yaml
@@ -6,7 +6,7 @@ jobs:
   static-code-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.2
+      - uses: actions/checkout@v3
 
       - id: common
         uses: ghga-de/gh-action-common@v1.0.2

--- a/.github/workflows/check_openapi_spec.yaml
+++ b/.github/workflows/check_openapi_spec.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - id: common
-        uses: ghga-de/gh-action-common@v1.0.2
+        uses: ghga-de/gh-action-common@v1.0.3
 
       - name: Check if openapi.yaml is up to date
         run: |

--- a/.github/workflows/check_openapi_spec.yaml
+++ b/.github/workflows/check_openapi_spec.yaml
@@ -7,7 +7,7 @@ jobs:
   static-code-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.2
+      - uses: actions/checkout@v3
 
       - id: common
         uses: ghga-de/gh-action-common@v1.0.2

--- a/.github/workflows/check_template_files.yaml
+++ b/.github/workflows/check_template_files.yaml
@@ -6,9 +6,9 @@ jobs:
   check-template-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3.1.2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Check template files

--- a/.github/workflows/dev_cd.yaml
+++ b/.github/workflows/dev_cd.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: get_commit_version
     steps:
-      - uses: actions/checkout@v2.4.2
+      - uses: actions/checkout@v3
         name: Check out code
 
       - uses: docker/setup-qemu-action@v2.0.0

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Static Code Analysis
     steps:
-      - uses: actions/checkout@v2.4.2
+      - uses: actions/checkout@v3
       - name: Retrieve main src dir
         id: main_src_dir
         run: |
           echo "MAIN_SRC_DIR=${PWD}/$(./scripts/get_package_name.py)" >> $GITHUB_OUTPUT
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3.1.2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install Dependencies

--- a/.github/workflows/unit_and_int_tests.yaml
+++ b/.github/workflows/unit_and_int_tests.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - id: common
-        uses: ghga-de/gh-action-common@v1.0.2
+        uses: ghga-de/gh-action-common@v1.0.3
 
       - name: Run pytest
         run: |

--- a/.github/workflows/unit_and_int_tests.yaml
+++ b/.github/workflows/unit_and_int_tests.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Unit and Integration Tests
 
     steps:
-      - uses: actions/checkout@v2.4.2
+      - uses: actions/checkout@v3
 
       - id: common
         uses: ghga-de/gh-action-common@v1.0.2


### PR DESCRIPTION
Currently we get some deprecation warnings in the logs because of old versions of GitHub actions.