### PR TITLE
Add .jinja ending to the license checker ignore list

### DIFF
--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -84,6 +84,7 @@ EXCLUDE_ENDINGS = [
     "xml",
     "yaml",
     "yml",
+    "jinja",
 ]
 
 # exclude any files with names that match any of the following regex:


### PR DESCRIPTION
This would be a useful addition to the template for the integration utility that is being built as it generates markdown from jinja templates.