### PR TITLE
Add separate requirements file for development

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -5,10 +5,14 @@ cd /workspace
 
 git config --global --add safe.directory /workspace
 
+# upgrade pip
+python -m pip install --upgrade pip
+
 # install in edit mode with testing dependencies
-pip install \
-    -e \
-    ".[all]"
+pip install -e .
+
+# install dev dependencies
+pip install -r requirements-dev.txt
 
 # install pre-commit hooks to git:
 pre-commit install

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install .
-          pip install -r requirements.dev
+          pip install -r requirements-dev.txt
       - uses: pre-commit/action@v3.0.0
         env:
           SKIP: no-commit-to-branch

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install .
+          pip install -r requirements.dev
       - uses: pre-commit/action@v3.0.0
         env:
           SKIP: no-commit-to-branch

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.9
       - name: Install Dependencies
         run: |
-          pip install ".[all]"
+          pip install .
       - uses: pre-commit/action@v3.0.0
         env:
           SKIP: no-commit-to-branch

--- a/.github/workflows/unit_and_int_tests.yaml
+++ b/.github/workflows/unit_and_int_tests.yaml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Run pytest
         run: |
+          pip install -r requirements-dev.txt
           export ${{ steps.common.outputs.CONFIG_YAML_ENV_VAR_NAME }}="${{ steps.common.outputs.CONFIG_YAML }}"
           pytest \
             --cov="${{ steps.common.outputs.MAIN_SRC_DIR }}" \
@@ -25,5 +26,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip3 install --upgrade coveralls
+          pip install --upgrade coveralls
           coveralls --service=github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 default_language_version:
   python: python3.9
 
-minimum_pre_commit_version: 2.17.0
+minimum_pre_commit_version: 3.0.0
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -37,21 +37,21 @@ repos:
       - id: debug-statements
       - id: debug-statements
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--profile, black]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.0
+    rev: v1.1.1
     hooks:
       - id: mypy
         args: [--no-warn-unused-ignores]
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.15.10
+    rev: v2.16.4
     hooks:
       - id: pylint
         args: [--disable=E0401]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: isort
         args: [--profile, black]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.0.0
     hooks:
       - id: mypy
         args: [--no-warn-unused-ignores]

--- a/.static_files
+++ b/.static_files
@@ -38,4 +38,5 @@ pytest.ini
 
 LICENSE
 requirements.txt
+requirements-dev.txt
 setup.py

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ that need modification. Once the adaptions are in place, please remove these #
 comments.
 
 The following should serve as a template for the final repo's README,
-please adapt it accordingly (e.g. replace all occurences of `my-microservice` or `my_microservice` with the final package name and don't forget to adapt the links):
+please adapt it accordingly (e.g. replace all occurrences of `my-microservice` or `my_microservice`
+with the final package name and don't forget to adapt the links):
 
 ---
 
@@ -62,7 +63,7 @@ For production-ready deployment, we recommend using Kubernetes, however,
 for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
-# The entrypoint is preconfigured:
+# The entrypoint is pre-configured:
 docker run -p 8080:8080 ghga/my-microservice:<version>
 ```
 
@@ -112,7 +113,7 @@ Then open this repository in vscode and run the command
 This will give you a full-fledged, pre-configured development environment including:
 - infrastructural dependencies of the service (databases, etc.)
 - all relevant vscode extensions pre-installed
-- pre-configured linting and auto-formating
+- pre-configured linting and auto-formatting
 - a pre-configured debugger
 - automatic license-header insertion
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 pytest==7.2.0
 pytest-asyncio==0.20.3
 pytest-cov==4.0.0
-mypy==1.1.1
+mypy==1.0.0
 mypy-extensions==1.0.0
 types-requests==2.28.11.7
 pylint==2.16.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,28 @@
+# requirements for development and testing of services
+
+pytest==7.2.0
+pytest-asyncio==0.20.3
+pytest-cov==4.0.0
+mypy==1.1.1
+mypy-extensions==1.0.0
+types-requests==2.28.11.7
+pylint==2.16.4
+click==8.1.3
+black==23.1.0
+flake8==6.0.0
+isort==5.12.0
+bandit==1.7.4
+pre-commit==3.1.1
+mkdocs==1.4.2
+mkdocs-autorefs==0.4.1
+mkdocs-material==9.0.3
+mkdocs-material-extensions==1.1.1
+mkdocstrings==0.19.1
+mkdocstrings-python-legacy==0.2.3
+# 3.4.1 -> 3.4.2 causes issues in hexkit, but 3.7.1 works again
+# but 3.7.1 currently does not work with ghga-connector and dcs
+testcontainers[kafka,mongo,postgresql]==3.4.1
+typer==0.7.0
+sqlalchemy-utils==0.39.0
+sqlalchemy-stubs==0.4
+httpx==0.23.3

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -58,7 +58,6 @@ EXCLUDE = [
     "LICENSE",  # is checked but not for the license header
     ".pre-commit-config.yaml",
     "docs",
-    "requirements.txt",
     ".vscode",
     ".mypy_cache",
     ".mypy.ini",
@@ -76,15 +75,16 @@ EXCLUDE = [
 EXCLUDE_ENDINGS = [
     "html",
     "ini",
+    "jinja",
     "json",
     "md",
     "pub",
     "pyc",
     "sec",
+    "txt",
     "xml",
     "yaml",
     "yml",
-    "jinja",
 ]
 
 # exclude any files with names that match any of the following regex:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,10 +36,13 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    # Please adapt to the current version of the library
-    # and remove the unneeded extras:
-    ghga-service-chassis-lib[api,mongo_connect,object_storage_dao,s3]==0.17.0
-
+    # Please adapt to the current versions of the libraries
+    # and remove the unneeded libraries and extras:
+    typer==0.7.0
+    # (needs to be changed to ghga-service-commons)
+    ghga-service-chassis-lib[api]==0.17.5
+    ghga-event-schemas==0.8.0
+    hexkit[akafka,s3,mongodb]==0.9.1
 
 python_requires = >= 3.9
 
@@ -47,15 +50,6 @@ python_requires = >= 3.9
 # Please adapt to package name:
 console_scripts =
     my-microservice = my_microservice.__main__:run
-
-[options.extras_require]
-dev =
-    # Please adapt to the current version of the library
-    ghga-service-chassis-lib[dev]==0.17.0
-
-all =
-    %(dev)s
-
 
 [options.packages.find]
 exclude = tests


### PR DESCRIPTION
This PR changes the microservice template so that dev-requirements are installed via a separate requirements-dev.txt file, instead of using the dev extra from the chassis lib or hexkit.