### PR TITLE
Fix misleading comment in dev_install

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -12,7 +12,7 @@ python -m pip install --upgrade pip
 pip install -r requirements.txt
 
 # install or upgrade dependencies for development and testing
-pip install -U -r requirements-dev.txt
+pip install --upgrade -r requirements-dev.txt
 
 # install pre-commit hooks to git
 pre-commit install

--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -11,8 +11,8 @@ python -m pip install --upgrade pip
 # install with all extras in editable mode
 pip install -r requirements.txt
 
-# install dependencies for development and testing
-pip install -r requirements-dev.txt
+# install or upgrade dependencies for development and testing
+pip install -U -r requirements-dev.txt
 
 # install pre-commit hooks to git
 pre-commit install

--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -8,11 +8,11 @@ git config --global --add safe.directory /workspace
 # upgrade pip
 python -m pip install --upgrade pip
 
-# install in edit mode with testing dependencies
-pip install -e .
+# install with all extras in editable mode
+pip install -r requirements.txt
 
-# install dev dependencies
+# install dependencies for development and testing
 pip install -r requirements-dev.txt
 
-# install pre-commit hooks to git:
+# install pre-commit hooks to git
 pre-commit install


### PR DESCRIPTION
Fix misleading comment and consistently use requirements files (these can then be changed without changing the dev-install script or GitHub actions). Also, upgrade the dev dependencies when running the script.