### PR TITLE
Install in editable mode in dev_install script

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -7,7 +7,7 @@ cd /workspace
 python -m pip install --upgrade pip
 
 # install with all extras in editable mode
-pip install -r requirements.txt
+pip install -e .[all]
 
 # install or upgrade dependencies for development and testing
 pip install --upgrade -r requirements-dev.txt


### PR DESCRIPTION
The `dev_install` script should install in editable mode (again). Currently it doesn't since there is no `-e` in the `requirements.txt` file.