### PR TITLE
Use service commons and update pylint configuration

### DIFF
--- a/.deprecated_files_ignore
+++ b/.deprecated_files_ignore
@@ -1,2 +1,2 @@
-# Optional list of files which are actually deprecetated in the template
+# Optional list of files which are actually deprecated in the template
 # but are still allowed to be used in the current repository

--- a/.pylintrc
+++ b/.pylintrc
@@ -541,6 +541,6 @@ valid-metaclass-classmethod-first-arg=cls
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+# "builtins.BaseException, builtins.Exception".
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/my_microservice/__main__.py
+++ b/my_microservice/__main__.py
@@ -15,7 +15,9 @@
 
 """Entrypoint of the package"""
 
-from ghga_service_chassis_lib.api import run_server
+import asyncio
+
+from ghga_service_commons.api import run_server
 
 from .api.main import app  # noqa: F401 pylint: disable=unused-import
 from .config import CONFIG, Config
@@ -24,7 +26,7 @@ from .config import CONFIG, Config
 def run(config: Config = CONFIG):
     """Run the service"""
     # Please adapt to package name
-    run_server(app="my_microservice.__main__:app", config=config)
+    asyncio.run(run_server(app="my_microservice.__main__:app", config=config))
 
 
 if __name__ == "__main__":

--- a/my_microservice/api/main.py
+++ b/my_microservice/api/main.py
@@ -20,7 +20,7 @@ Additional endpoints might be structured in dedicated modules
 """
 
 from fastapi import Depends, FastAPI
-from ghga_service_chassis_lib.api import configure_app
+from ghga_service_commons.api import configure_app
 
 from ..config import CONFIG
 from ..core.greeting import generate_greeting

--- a/my_microservice/config.py
+++ b/my_microservice/config.py
@@ -15,8 +15,8 @@
 
 """Config Parameter Modeling and Parsing"""
 
-from ghga_service_chassis_lib.api import ApiConfigBase
-from ghga_service_chassis_lib.config import config_from_yaml
+from ghga_service_commons.api import ApiConfigBase
+from hexkit.config import config_from_yaml
 
 from .models import SupportedLanguages
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,9 @@ install_requires =
     # Please adapt to the current versions of the libraries
     # and remove the unneeded libraries and extras:
     typer==0.7.0
-    # (needs to be changed to ghga-service-commons)
-    ghga-service-chassis-lib[api]==0.17.5
+    ghga-service-commons[api]==0.2.0
     ghga-event-schemas==0.8.0
-    hexkit[akafka,s3,mongodb]==0.9.1
+    hexkit[akafka,s3,mongodb]==0.9.2
 
 python_requires = >= 3.9
 


### PR DESCRIPTION
- Migrate from GHGA service chassis lib to GHGA service commons
- Update the pylint configuration to avoid a deprecation warning
- Improve the `update_config_docs` script so that it shows diffs (helpful to debug failing GitHub action)