### PR TITLE
Support arm64 by using multi-platform builds

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -76,7 +76,7 @@ jobs:
         id: docker_build
         with:
           push: true
-          #       platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64
           tags: "ghga/${{ github.event.repository.name }}:${{ needs.verify_version.outputs.version }}"
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -59,19 +59,19 @@ jobs:
       - uses: actions/checkout@v3
         name: Check out code
 
-      - uses: docker/setup-qemu-action@v2.0.0
+      - uses: docker/setup-qemu-action@v2
         name: Set up QEMU
 
-      - uses: docker/setup-buildx-action@v2.5.0
+      - uses: docker/setup-buildx-action@v2
         name: Set up Docker Buildx
 
-      - uses: docker/login-action@v2.1.0
+      - uses: docker/login-action@v2
         name: Login to DockerHub
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v4.0.0
+      - uses: docker/build-push-action@v4
         name: Build and push
         id: docker_build
         with:


### PR DESCRIPTION
Currently the GHGA services are only built for x86_64/amd64 architectures. Not only does this limit the adoptability on more cost-efficient arm nodes, but also poses a problem for developers operating on arm cpus (such as newer MacBooks).

This can be fixed by adding the option platforms: linux/amd64,linux/arm64 to the docer/build-push-action.

This was already applied to [metadata-catalog](https://github.com/ghga-de/metadata-catalog/pull/45).