### PR TITLE
fix docker-py incompatibility with requests/urllib3 (GSI-110)

### DIFF
--- a/requirements-dev-common.txt
+++ b/requirements-dev-common.txt
@@ -23,6 +23,8 @@ click==8.1.3
 typer==0.7.0
 
 httpx==0.23.3
+pytest-httpx==0.21.3
+
 
 mkdocs==1.4.2
 mkdocs-autorefs==0.4.1
@@ -30,3 +32,8 @@ mkdocs-material==9.0.3
 mkdocs-material-extensions==1.1.1
 mkdocstrings==0.19.1
 mkdocstrings-python-legacy==0.2.3
+
+# work around until this issue is solved:
+# https://github.com/docker/docker-py/issues/3113
+urllib3==1.26.15
+requests==2.28.2


### PR DESCRIPTION
```
- docker-py is a dependency of python-testcontainers
- moreover, added pytest-httpx plugin for request mocking
```