### PR TITLE
Ignore ruff rules from pydocstyle

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -16,6 +16,10 @@ ignore = [
     "N818", # Errors need to have Error suffix
     "B008", # function call in arg defaults,
     "PLR2004", # magic numbers should be constants
+    "D205", # blank-line-after-summary
+    "D400", # first doc line ends in period
+    "D401", # non-imperative-mood
+    "D107", # missing docstring in __init__
 ]
 
 line-length = 88
@@ -40,7 +44,7 @@ fixable = [
     "D", # pydocstyle
 ]
 
-src = ["src", "tests", "examples"]
+src = ["src", "tests", "examples", "scripts"]
 
 target-version = "py39"
 

--- a/.static_files
+++ b/.static_files
@@ -24,6 +24,7 @@ scripts/update_template_files.py
 scripts/update_openapi_docs.py
 scripts/update_readme.py
 scripts/update_lock.py
+scripts/update_hook_revs.py
 scripts/README.md
 
 .github/workflows/check_config_docs.yaml
@@ -46,7 +47,6 @@ pytest.ini
 
 LICENSE
 requirements-dev-common.in
-setup.py
 
 .readme_template.md
 readme_generation.md

--- a/scripts/update_config_docs.py
+++ b/scripts/update_config_docs.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import yaml
 from pydantic import BaseSettings
+
 from script_utils.cli import echo_failure, echo_success, run
 
 HERE = Path(__file__).parent.resolve()

--- a/scripts/update_lock.py
+++ b/scripts/update_lock.py
@@ -30,6 +30,7 @@ from tempfile import TemporaryDirectory
 import stringcase
 import tomli
 import tomli_w
+
 from script_utils import cli
 
 REPO_ROOT_DIR = Path(__file__).parent.parent.resolve()

--- a/scripts/update_openapi_docs.py
+++ b/scripts/update_openapi_docs.py
@@ -22,6 +22,7 @@ from difflib import unified_diff
 from pathlib import Path
 
 import yaml
+
 from script_utils.cli import echo_failure, echo_success, run
 from script_utils.fastapi_app_location import app
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -26,8 +26,9 @@ from string import Template
 import jsonschema2md
 import tomli
 from pydantic import BaseModel, Field
-from script_utils.cli import echo_failure, echo_success, run
 from stringcase import spinalcase, titlecase
+
+from script_utils.cli import echo_failure, echo_success, run
 
 ROOT_DIR = Path(__file__).parent.parent.resolve()
 PYPROJECT_TOML_PATH = ROOT_DIR / "pyproject.toml"


### PR DESCRIPTION
While updating hexkit, it was decided that some of the rules from pydocstyle are impractical and to ignore them.
Including:
    "D205", # blank-line-after-summary
    "D400", # first doc line ends in period
    "D401", # non-imperative-mood 
    "D107", # missing docstring in __init__ function

Also removed setup.py from static files and included update_hook_revs.py. Somehow those changes got excluded from previous PRs.