### PR TITLE
Script to check for outdated dependencies (GSI 371)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,7 +2,8 @@ name: CD
 
 on:
   release:
-    types: [published]
+    types:
+      [published]
       # trigger only on new release
 
 jobs:
@@ -44,7 +45,7 @@ jobs:
         name: Verify package version vs tag version
         # package version must be same with tag version
         run: |
-          PKG_VER="$(python setup.py --version)"
+          PKG_VER="$(grep -oP 'version = "\K[^"]+' pyproject.toml)"
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is ${{ steps.get_version_tag.outputs.version }}" >&2
           if [ "$PKG_VER" != "${{ steps.get_version_tag.outputs.version }}" ]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
         name: "ensure hooks are up to date"
         language: python
         additional_dependencies:
+          - "packaging"
           - "typer"
         fail_fast: true
         always_run: true

--- a/.static_files
+++ b/.static_files
@@ -25,6 +25,7 @@ scripts/update_openapi_docs.py
 scripts/update_readme.py
 scripts/update_lock.py
 scripts/update_hook_revs.py
+scripts/list_outdated_dependencies.py
 scripts/README.md
 
 .github/workflows/check_config_docs.yaml

--- a/scripts/list_outdated_dependencies.py
+++ b/scripts/list_outdated_dependencies.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Check capped dependencies for newer versions."""
+import re
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import httpx
+import stringcase
+import tomli
+from packaging.requirements import Requirement
+
+from script_utils import cli
+
+REPO_ROOT_DIR = Path(__file__).parent.parent.resolve()
+PYPROJECT_TOML_PATH = REPO_ROOT_DIR / "pyproject.toml"
+DEV_DEPS_PATH = REPO_ROOT_DIR / "requirements-dev.in"
+LOCK_FILE_PATH = REPO_ROOT_DIR / "requirements-dev.txt"
+
+
+def get_transitive_deps(exclude: set[str]) -> list[str]:
+    """Inspect the lock file to get the transitive dependencies"""
+    dependency_pattern = re.compile(r"([^=\s]+==[^\s]*?)\s")
+
+    # Get the set of dependencies from the requirements-dev.txt lock file
+    with open(LOCK_FILE_PATH, encoding="utf-8") as lock_file:
+        lines = lock_file.readlines()
+
+    dependencies = []
+    for line in lines:
+        if match := re.match(dependency_pattern, line):
+            dependency = match.group(1)
+            requirement = Requirement(dependency)
+            if requirement not in exclude:
+                dependencies.append(dependency)
+    return dependencies
+
+
+def exclude_from_dependency_list(*, package_name: str, dependencies: list) -> list:
+    """Exclude the specified package from the provided dependency list."""
+
+    return [
+        dependency
+        for dependency in dependencies
+        if not dependency.startswith(package_name)
+    ]
+
+
+def remove_self_dependencies(pyproject: dict) -> dict:
+    """Filter out self dependencies (dependencies of the package on it self) from the
+    dependencies and optional-dependencies in the provided pyproject metadata."""
+
+    if "project" not in pyproject:
+        return pyproject
+
+    modified_pyproject = deepcopy(pyproject)
+
+    project_metadata = modified_pyproject["project"]
+
+    package_name = stringcase.spinalcase(project_metadata.get("name"))
+
+    if not package_name:
+        raise ValueError("The provided project metadata does not contain a name.")
+
+    if "dependencies" in project_metadata:
+        project_metadata["dependencies"] = exclude_from_dependency_list(
+            package_name=package_name, dependencies=project_metadata["dependencies"]
+        )
+
+    if "optional-dependencies" in project_metadata:
+        for group in project_metadata["optional-dependencies"]:
+            project_metadata["optional-dependencies"][
+                group
+            ] = exclude_from_dependency_list(
+                package_name=package_name,
+                dependencies=project_metadata["optional-dependencies"][group],
+            )
+
+    return modified_pyproject
+
+
+def get_main_deps_pyproject(modified_pyproject: dict[str, Any]) -> list[str]:
+    """Get a list of the dependencies from pyproject.toml"""
+
+    dependencies: list[str] = []
+    if "dependencies" in modified_pyproject["project"]:
+        dependencies = modified_pyproject["project"]["dependencies"]
+
+    return dependencies
+
+
+def get_optional_deps_pyproject(modified_pyproject: dict[str, Any]) -> list[str]:
+    """Get a list of the optional dependencies from pyproject.toml"""
+
+    dependencies: list[str] = []
+
+    if "optional-dependencies" in modified_pyproject["project"]:
+        for optional_dependency_list in modified_pyproject["project"][
+            "optional-dependencies"
+        ]:
+            dependencies.extend(
+                modified_pyproject["project"]["optional-dependencies"][
+                    optional_dependency_list
+                ]
+            )
+
+    return dependencies
+
+
+def get_modified_pyproject() -> dict[str, Any]:
+    """Get a copy of pyproject.toml with any self-referencing dependencies removed."""
+    with open(PYPROJECT_TOML_PATH, "rb") as pyproject_toml:
+        pyproject = tomli.load(pyproject_toml)
+
+    modified_pyproject = remove_self_dependencies(pyproject)
+    return modified_pyproject
+
+
+def get_deps_dev() -> list[str]:
+    """Get a list of raw dependency strings from requirements-dev.in"""
+    dependencies = []
+    with open(DEV_DEPS_PATH, encoding="utf-8") as dev_deps:
+        lines = dev_deps.readlines()
+
+    for line in lines:
+        if (
+            line.strip().startswith("#")  # skip comments
+            or len(line.strip()) == 0  # skip empty lines
+            or "requirements-dev-common.in" in line  # skip the inclusion line
+        ):
+            continue
+
+        dependencies.append(line)
+
+    return dependencies
+
+
+def get_version_from_pypi(package_name: str) -> str:
+    """Make a call to PyPI to get the version information about `package_name`."""
+    try:
+        with httpx.Client(timeout=10) as client:
+            response = client.get(f"https://pypi.org/pypi/{package_name}/json")
+            body = response.json()
+            version = body["info"]["version"]
+    except (httpx.RequestError, KeyError):
+        cli.echo_failure(f"Unable to retrieve information for package '{package_name}'")
+        sys.exit(1)
+
+    return version
+
+
+def get_outdated_deps(dependencies: list[str], strip: bool = False) -> list[list[str]]:
+    """Determine which packages have updates available outside of pinned ranges."""
+    outdated: list[list[str]] = []
+    for dependency in dependencies:
+        # Convert string into Requirement object so we can reference its parts
+        requirement = Requirement(dependency)
+
+        pypi_version = get_version_from_pypi(requirement.name)
+
+        specified = str(requirement.specifier)
+
+        # Strip the specifier symbols from the front of the string if desired
+        if strip:
+            specified = specified.lstrip("<=>!~")
+
+        # append package name, specified version, and latest available version
+        if not requirement.specifier.contains(pypi_version):
+            outdated.append([requirement.name, specified, pypi_version])
+    outdated.sort()
+    return outdated
+
+
+def print_table(
+    rows: list[list[str]],
+    headers: list[str],
+    delimiter: str = " | ",
+):
+    """
+    List outdated dependencies in a formatted table.
+
+    Args:
+        `outdated`: A list of lists containing strings.
+        `headers`: A list containing the header strings for the table columns.
+    """
+    header_lengths = [len(header) for header in headers]
+
+    # Find the maximum length of each column
+    col_widths = [max(len(str(cell)) for cell in col) for col in zip(*rows)]
+
+    # Create a row format based on the maximum column widths
+    row_format = delimiter.join(
+        f"{{:<{max(width, header_len)}}}"
+        for width, header_len in zip(col_widths, header_lengths)
+    )
+
+    print("  " + row_format.format(*headers))
+    for dependency in rows:
+        print("  " + row_format.format(*dependency))
+
+
+def main(transitive: bool = False):
+    """Check capped dependencies for newer versions.
+
+    Examine `pyproject.toml` and `requirements-dev.in` for capped dependencies.
+    Make a call to PyPI to see if any newer versions exist.
+
+    Use `transitive` to show outdated transitive dependencies.
+    """
+    modified_pyproject: dict[str, Any] = get_modified_pyproject()
+    main_dependencies = get_main_deps_pyproject(modified_pyproject)
+    optional_dependencies = get_optional_deps_pyproject(modified_pyproject)
+    dev_dependencies = get_deps_dev()
+
+    outdated_main = get_outdated_deps(main_dependencies)
+    outdated_optional = get_outdated_deps(optional_dependencies)
+    outdated_dev = get_outdated_deps(dev_dependencies)
+
+    found_outdated = any([outdated_main, outdated_optional, outdated_dev])
+    headers = ["PACKAGE", "SPECIFIED", "AVAILABLE"]
+    if outdated_main:
+        location = PYPROJECT_TOML_PATH.name + " - dependencies"
+        cli.echo_failure(f"Outdated dependencies from {location}:")
+        print_table(outdated_main, headers)
+    if outdated_optional:
+        location = PYPROJECT_TOML_PATH.name + " - optional-dependencies"
+        cli.echo_failure(f"Outdated dependencies from {location}:")
+        print_table(outdated_optional, headers)
+    if outdated_dev:
+        cli.echo_failure(f"Outdated dependencies from {DEV_DEPS_PATH.name}:")
+        print_table(outdated_dev, headers)
+
+    if not found_outdated:
+        cli.echo_success("All top-level dependencies up to date.")
+
+    if transitive:
+        top_level: set[str] = set(
+            [item[0] for item in outdated_main + outdated_optional + outdated_dev]
+        )
+
+        print("\nRetrieving transitive dependency information...")
+        transitive_dependencies = get_transitive_deps(exclude=top_level)
+        outdated_transitive = get_outdated_deps(transitive_dependencies, strip=True)
+
+        if outdated_transitive:
+            headers[1] = "PINNED"
+
+            cli.echo_failure("Outdated transitive dependencies:")
+            print_table(outdated_transitive, headers)
+        else:
+            cli.echo_success("All transitive dependencies up to date.")
+
+
+if __name__ == "__main__":
+    cli.run(main)

--- a/scripts/list_outdated_dependencies.py
+++ b/scripts/list_outdated_dependencies.py
@@ -188,7 +188,7 @@ def main(transitive: bool = False):
 
     if transitive:
         top_level: set[str] = {
-            item[0] for item in outdated_main + outdated_optional + outdated_dev
+            item.name for item in outdated_main + outdated_optional + outdated_dev
         }
 
         print("\nRetrieving transitive dependency information...")

--- a/scripts/list_outdated_dependencies.py
+++ b/scripts/list_outdated_dependencies.py
@@ -165,9 +165,11 @@ def get_version_from_pypi(package_name: str, client: httpx.Client) -> str:
     return version
 
 
-def get_outdated_deps(dependencies: list[str], strip: bool = False) -> list[list[str]]:
+def get_outdated_deps(
+    dependencies: list[str], strip: bool = False
+) -> list[tuple[str, ...]]:
     """Determine which packages have updates available outside of pinned ranges."""
-    outdated: list[list[str]] = []
+    outdated: list[tuple[str, ...]] = []
     with httpx.Client(timeout=10) as client:
         for dependency in dependencies:
             # Convert string into Requirement object so we can reference its parts
@@ -183,13 +185,13 @@ def get_outdated_deps(dependencies: list[str], strip: bool = False) -> list[list
 
             # append package name, specified version, and latest available version
             if not requirement.specifier.contains(pypi_version):
-                outdated.append([requirement.name, specified, pypi_version])
+                outdated.append((requirement.name, specified, pypi_version))
     outdated.sort()
     return outdated
 
 
 def print_table(
-    rows: list[list[str]],
+    rows: list[tuple[str, ...]],
     headers: list[str],
     delimiter: str = " | ",
 ):
@@ -251,9 +253,9 @@ def main(transitive: bool = False):
         cli.echo_success("All top-level dependencies up to date.")
 
     if transitive:
-        top_level: set[str] = set(
-            [item[0] for item in outdated_main + outdated_optional + outdated_dev]
-        )
+        top_level: set[str] = {
+            item[0] for item in outdated_main + outdated_optional + outdated_dev
+        }
 
         print("\nRetrieving transitive dependency information...")
         transitive_dependencies = get_transitive_deps(exclude=top_level)

--- a/scripts/list_outdated_dependencies.py
+++ b/scripts/list_outdated_dependencies.py
@@ -135,19 +135,14 @@ def get_modified_pyproject() -> dict[str, Any]:
 
 def get_deps_dev() -> list[str]:
     """Get a list of raw dependency strings from requirements-dev.in"""
-    dependencies = []
     with open(DEV_DEPS_PATH, encoding="utf-8") as dev_deps:
-        lines = dev_deps.readlines()
-
-    for line in lines:
-        if (
-            line.strip().startswith("#")  # skip comments
-            or len(line.strip()) == 0  # skip empty lines
-            or "requirements-dev-common.in" in line  # skip the inclusion line
-        ):
-            continue
-
-        dependencies.append(line)
+        dependencies = [
+            line
+            for line in (line.strip() for line in dev_deps)
+            if line  # skip empty lines
+            and not line.startswith("#")  # skip comments
+            and "requirements-dev-common.in" not in line  # skip inclusion line
+        ]
 
     return dependencies
 

--- a/scripts/script_utils/deps.py
+++ b/scripts/script_utils/deps.py
@@ -1,0 +1,75 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Contains utils for working with dependencies, lock files, etc."""
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import stringcase
+import tomli
+
+
+def exclude_from_dependency_list(*, package_name: str, dependencies: list) -> list:
+    """Exclude the specified package from the provided dependency list."""
+
+    return [
+        dependency
+        for dependency in dependencies
+        if not dependency.startswith(package_name)
+    ]
+
+
+def remove_self_dependencies(pyproject: dict) -> dict:
+    """Filter out self dependencies (dependencies of the package on it self) from the
+    dependencies and optional-dependencies in the provided pyproject metadata."""
+
+    if "project" not in pyproject:
+        return pyproject
+
+    modified_pyproject = deepcopy(pyproject)
+
+    project_metadata = modified_pyproject["project"]
+
+    package_name = stringcase.spinalcase(project_metadata.get("name"))
+
+    if not package_name:
+        raise ValueError("The provided project metadata does not contain a name.")
+
+    if "dependencies" in project_metadata:
+        project_metadata["dependencies"] = exclude_from_dependency_list(
+            package_name=package_name, dependencies=project_metadata["dependencies"]
+        )
+
+    if "optional-dependencies" in project_metadata:
+        for group in project_metadata["optional-dependencies"]:
+            project_metadata["optional-dependencies"][
+                group
+            ] = exclude_from_dependency_list(
+                package_name=package_name,
+                dependencies=project_metadata["optional-dependencies"][group],
+            )
+
+    return modified_pyproject
+
+
+def get_modified_pyproject(pyproject_toml_path: Path) -> dict[str, Any]:
+    """Get a copy of pyproject.toml with any self-referencing dependencies removed."""
+    with open(pyproject_toml_path, "rb") as pyproject_toml:
+        pyproject = tomli.load(pyproject_toml)
+
+    modified_pyproject = remove_self_dependencies(pyproject)
+    return modified_pyproject

--- a/scripts/script_utils/deps.py
+++ b/scripts/script_utils/deps.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 """Contains utils for working with dependencies, lock files, etc."""
-
 from copy import deepcopy
 from pathlib import Path
 from typing import Any

--- a/scripts/script_utils/lock_deps.py
+++ b/scripts/script_utils/lock_deps.py
@@ -1,0 +1,46 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Provides a function to get all dependencies from the lock file"""
+import re
+from pathlib import Path
+from typing import Optional
+
+from packaging.requirements import Requirement
+
+
+def get_lock_file_deps(
+    lock_file_path: Path,
+    exclude: Optional[set[str]] = None,
+) -> list[Requirement]:
+    """Inspect the lock file to get the dependencies.
+
+    Return a list of Requirements objects that contain the dependency info.
+    """
+    dependency_pattern = re.compile(r"([^=\s]+==[^\s]*?)\s")
+
+    # Get the set of dependencies from the provided lock file
+    with open(lock_file_path, encoding="utf-8") as lock_file:
+        lines = lock_file.readlines()
+
+    dependencies: list[Requirement] = []
+    for line in lines:
+        if match := re.match(dependency_pattern, line):
+            dependency_string = match.group(1)
+            requirement = Requirement(dependency_string)
+            if not exclude or requirement.name not in exclude:
+                dependencies.append(requirement)
+
+    return dependencies


### PR DESCRIPTION
This adds a script (`scripts/list_outdated_dependencies.py`) that is meant to:
- List outdated capped dependencies based on what is _specified_.
- When used with `--transitive`, list outdated transitive dependencies based on what is _pinned in the lock file_.

It works by obtaining the latest version of a package from PyPI and seeing whether that version satisfies the version range we have specified.
Uncapped dependencies should therefore always be omitted by this method.

For example, if we required hexkit like this:
`hexkit ~= 0.9.0`
and the latest version on PyPI is 0.10.x, then the script will see that 0.10.x is not contained within the specifier `~= 0.9.0` and flag it as outdated. 
If the specifier were uncapped, e.g. `hexkit >= 0.9.0`, then it would not be flagged as outdated because 0.10.x also satisfies `>= 0.9.0`.

Originally, this functionality was proposed to be included in the `update_lock.py` script. Even though some of the functionality is shared (e.g. examining a modified `pyproject.toml`), it would have been a shoehorn job. `update_lock.py` serves to resolve all project dependencies and update the lock files (and it takes some time), while the purpose of this script is to:
1. Highlight dependency specifiers that might need reconsideration
2. Display outdated transitive dependencies so we may see if any are _so_ outdated that they warrant a second look at the associated top-level requirement(s).

