### PR TITLE
Add coverage config with source mapping

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[paths]
+source =
+  src
+  /workspace/src
+  **/lib/python*/site-packages

--- a/.static_files
+++ b/.static_files
@@ -38,6 +38,7 @@ scripts/README.md
 
 example_data/README.md
 
+.coveragerc
 .editorconfig
 .gitattributes
 .gitignore

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -15,10 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: skip-file
-
 """This script checks that the license and license headers
-exists and that they are up to date.
+exist and that they are up to date.
 """
 
 import argparse
@@ -48,6 +46,7 @@ EXCLUDE = [
     "sdist",
     "wheels",
     "pip-wheel-metadata",
+    ".coveragerc",
     ".git",
     ".github",
     ".flake8",
@@ -237,7 +236,7 @@ def normalized_text(text: str, chars_to_trim: list[str] = COMMENT_CHARS) -> str:
 
 
 def format_copyright_template(copyright_template: str, author: str) -> str:
-    """Formats license header by inserting the specified author for every occurence of
+    """Formats license header by inserting the specified author for every occurrence of
     "{author}" in the header template.
     """
     return normalized_text(copyright_template.replace("{author}", author))
@@ -330,7 +329,7 @@ def check_copyright_notice(
     author (str, optional):
         The author that shall be included in the license header.
         It will replace any appearance of "{author}" in the license
-        header. This defaults to an auther info for GHGA.
+        header. This defaults to an author info for GHGA.
 
     """
     # If the global_copyright is already set, check if the current copyright is

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -15,7 +15,10 @@
 
 """Test dummy."""
 
+from my_microservice.core.greeting import generate_greeting
+
 
 def test_dummy():
-    """Just makes the CI pass."""
-    assert True
+    """A very simple example test."""
+    greeting = generate_greeting("monde", "French", True)
+    assert greeting.message == "Salut monde!"


### PR DESCRIPTION
This PR adds a coverage configuration file that maps the site-packages location to the workspace location.

This removes the long leading path that otherwise appears in the coverage reports.

It also makes the dummy test access the core module so that we can see a coverage report in the template.