### PR TITLE
Do not install additional requirements

### DIFF
--- a/.description.md
+++ b/.description.md
@@ -1,4 +1,4 @@
-<!-- Please provide a short overview of the features of this service.-->
+<!-- Please provide a short overview of the features of this service. -->
 
 This repo is a template for creating a new microservice.
 
@@ -6,19 +6,20 @@ The directories, files, and their structure herein are recommendations
 from the GHGA Dev Team.
 
 ### Naming Conventions
-The github repository contains only lowercase letters, numbers, and hyphens "-",
+
+The GitHub repository contains only lowercase letters, numbers, and hyphens "-",
 e.g.: `my-microservice`
 
-The python package (and thus the source repository) contains underscores "_"
+The Python package (and thus the source repository) contains underscores "_"
 instead of hyphens, e.g.: `my_microservice`
 However, an abbreviated version is prefered as package name.
 
 ### Adapt to your service
-This is just a template and needs some adaption to your specific use case.
 
-Please search for **"please adapt"** comments. They will indicate all locations
-that need modification. Once the adaptions are in place, please remove these #
-comments.
+This is just a template and needs some adaptation to your specific use case.
+
+Please search for **"please adapt"** comments. They will indicate all locations that
+need modification. Once the adaptations are in place, please remove these comments.
 
 Finally, follow the instructions to generate the README.md described in
 [`./readme_generation.md`](./readme_generation.md). Please also adapt this markdown file

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,10 @@ RUN apt upgrade -y
 WORKDIR /service
 COPY --from=builder /service/requirements.txt /service
 RUN pip install --no-deps -r requirements.txt
+RUN rm requirements.txt
 COPY --from=builder /service/dist/ /service
-RUN pip install *.whl
+RUN pip install --no-deps *.whl
+RUN rm *.whl
 # create new user and execute as that user
 RUN useradd --create-home appuser
 WORKDIR /home/appuser

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ My-Microservice - a short description
 
 ## Description
 
-<!-- Please provide a short overview of the features of this service.-->
+<!-- Please provide a short overview of the features of this service. -->
 
 This repo is a template for creating a new microservice.
 
@@ -16,19 +16,20 @@ The directories, files, and their structure herein are recommendations
 from the GHGA Dev Team.
 
 ### Naming Conventions
-The github repository contains only lowercase letters, numbers, and hyphens "-",
+
+The GitHub repository contains only lowercase letters, numbers, and hyphens "-",
 e.g.: `my-microservice`
 
-The python package (and thus the source repository) contains underscores "_"
+The Python package (and thus the source repository) contains underscores "_"
 instead of hyphens, e.g.: `my_microservice`
 However, an abbreviated version is prefered as package name.
 
 ### Adapt to your service
-This is just a template and needs some adaption to your specific use case.
 
-Please search for **"please adapt"** comments. They will indicate all locations
-that need modification. Once the adaptions are in place, please remove these #
-comments.
+This is just a template and needs some adaptation to your specific use case.
+
+Please search for **"please adapt"** comments. They will indicate all locations that
+need modification. Once the adaptations are in place, please remove these comments.
 
 Finally, follow the instructions to generate the README.md described in
 [`./readme_generation.md`](./readme_generation.md). Please also adapt this markdown file


### PR DESCRIPTION
Rely only on the requirements.txt lock file for installing dependencies and do not install additional dependencies when installing the wheel, to make the build process completely reproducible. If a requirement is not contained in the lock file, this should be considered an error and make the service fail instead of being silently fixed by the pip install command.