### PR TITLE
Remove BaseSettings return type annotation

### DIFF
--- a/scripts/update_config_docs.py
+++ b/scripts/update_config_docs.py
@@ -29,11 +29,6 @@ from typing import Any
 
 import yaml
 
-try:
-    from pydantic_settings import BaseSettings
-except ImportError:  # fallback for pydantic v1
-    from pydantic import BaseSettings  # type: ignore [no-redef]
-
 from script_utils.cli import echo_failure, echo_success, run
 
 HERE = Path(__file__).parent.resolve()
@@ -48,7 +43,7 @@ class ValidationError(RuntimeError):
     """Raised when validation of config documentation fails."""
 
 
-def get_config_class() -> type[BaseSettings]:
+def get_config_class():
     """
     Dynamically imports and returns the Config class from the current service.
     This makes the script service repo agnostic.


### PR DESCRIPTION
The move to pydantic v2 includes changing `BaseSettings` import from pydantic to pydantic_settings. The common scripts in the microservice template need to be agnostic in this regard to avoid forcing the pydantic v2 changes and disturbing current tickets or PRs. The only spot that has caused any issue in this regard is the return type annotation for the `get_config_class` function in `scripts/update_config_docs.py`. If we remove that annotation, we can remove the BaseSettings import completely and not have to worry about any workaround. 

The previous solution (workaround) had a minor flaw. While the mypy `type: ignore` was valid for repos that moved to pydantic v2, it would be seen as unused for any repos still on pydantic v1. 