### PR TITLE
Adjust test badge URL to match new filename

### DIFF
--- a/.readme_template.md
+++ b/.readme_template.md
@@ -1,5 +1,5 @@
 
-[![tests](https://github.com/ghga-de/$name/actions/workflows/unit_and_int_tests.yaml/badge.svg)](https://github.com/ghga-de/$name/actions/workflows/unit_and_int_tests.yaml)
+[![tests](https://github.com/ghga-de/$name/actions/workflows/tests.yaml/badge.svg)](https://github.com/ghga-de/$name/actions/workflows/unit_and_int_tests.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/ghga-de/$name/badge.svg?branch=main)](https://coveralls.io/github/ghga-de/$name?branch=main)
 
 # $title

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![tests](https://github.com/ghga-de/microservice-repository-template/actions/workflows/unit_and_int_tests.yaml/badge.svg)](https://github.com/ghga-de/microservice-repository-template/actions/workflows/unit_and_int_tests.yaml)
+[![tests](https://github.com/ghga-de/microservice-repository-template/actions/workflows/tests.yaml/badge.svg)](https://github.com/ghga-de/microservice-repository-template/actions/workflows/unit_and_int_tests.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/ghga-de/microservice-repository-template/badge.svg?branch=main)](https://coveralls.io/github/ghga-de/microservice-repository-template?branch=main)
 
 # Microservice Repository Template


### PR DESCRIPTION
This patch adjusts the test badge URL in the README template to match the new filename of the pytest workflow definition file (`tests.yaml`)