### PR TITLE
Fix conditional in build action

### DIFF
--- a/.github/workflows/ci_workflow_dispatch.yaml
+++ b/.github/workflows/ci_workflow_dispatch.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   fetch-tag:
     runs-on: ubuntu-latest
+    if: ( github.event.action == 'workflow_dispatch' || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build') ) || ( github.event.action == 'labeled' && github.event.label.name == 'build' )
     steps:
       - id: fetch-tag
         uses: ghga-de/gh-action-fetch-tag@v1

--- a/.github/workflows/ci_workflow_dispatch.yaml
+++ b/.github/workflows/ci_workflow_dispatch.yaml
@@ -12,7 +12,6 @@ on:
 jobs:
   fetch-tag:
     runs-on: ubuntu-latest
-    if: ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build') ) || ( github.event.action == 'labeled' && github.event.label.name == 'build' )
     steps:
       - id: fetch-tag
         uses: ghga-de/gh-action-fetch-tag@v1


### PR DESCRIPTION
Currently the build action is not triggered on `workflow-dispatch` events due to the conditional (see our hacky dcs [branch](https://github.com/ghga-de/download-controller-service/blob/add-logging-for-integration-issues/.github/workflows/ci_workflow_dispatch.yaml)). Since we need to retrieve the latest tag in both cases, I would suggest extending it.