### PR TITLE
Fix conditional in job

### DIFF
--- a/.github/workflows/ci_workflow_dispatch.yaml
+++ b/.github/workflows/ci_workflow_dispatch.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   fetch-tag:
     runs-on: ubuntu-latest
-    if: ( github.event.action == 'workflow_dispatch' || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build') ) || ( github.event.action == 'labeled' && github.event.label.name == 'build' )
+    if:  github.event_name == 'workflow_dispatch' || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build') ) || ( github.event.action == 'labeled' && github.event.label.name == 'build' )
     steps:
       - id: fetch-tag
         uses: ghga-de/gh-action-fetch-tag@v1


### PR DESCRIPTION
Fixes brackets and variable in conditional. The name of the action is accessible with [`github.event_name`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-contextl), e.g. `workflow_dispatch`. The variable [`github.action.event`](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=auto_merge_disabled#pull_request) is its type, e.g. `labeled`.