### PR TITLE
Patch ruff linter rules

### DIFF
--- a/.pyproject_generation/pyproject_template.toml
+++ b/.pyproject_generation/pyproject_template.toml
@@ -32,6 +32,16 @@ exclude = [
     "build",
     "dist",
 ]
+line-length = 88
+src = ["src", "tests", "examples", "scripts"]
+target-version = "py39"
+
+[tool.ruff.lint]
+fixable = [
+    "UP", # e.g. List -> list
+    "I", # sort imports
+    "D", # pydocstyle
+]
 ignore = [
     "E", # pycodestyle errors
     "W", # pycodestyle warnings - pycodestyle covered by black
@@ -49,7 +59,6 @@ ignore = [
     "D206", # indent-with-spaces (ignored for formatter)
     "D300", # triple-single-quotes (ignored for formatter)
 ]
-line-length = 88
 select = [
     "C90", # McCabe Complexity
     "F", # pyflakes codes
@@ -63,25 +72,18 @@ select = [
     "SIM", # flake8-simplify
     "D", # pydocstyle
 ]
-fixable = [
-    "UP", # e.g. List -> list
-    "I", # sort imports
-    "D", # pydocstyle
-]
-src = ["src", "tests", "examples", "scripts"]
-target-version = "py39"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "scripts/*" = ["PL", "S", "SIM", "D"]
 "tests/*" = ["S", "SIM", "PLR", "B011"]
 ".devcontainer/*" = ["S", "SIM", "D"]
 "examples/*" = ["S", "D"]
 "__init__.py" = ["D"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "pep257"
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,21 @@ exclude = [
     "build",
     "dist",
 ]
+line-length = 88
+src = [
+    "src",
+    "tests",
+    "examples",
+    "scripts",
+]
+target-version = "py39"
+
+[tool.ruff.lint]
+fixable = [
+    "UP",
+    "I",
+    "D",
+]
 ignore = [
     "E",
     "W",
@@ -70,7 +85,6 @@ ignore = [
     "D206",
     "D300",
 ]
-line-length = 88
 select = [
     "C90",
     "F",
@@ -84,23 +98,11 @@ select = [
     "SIM",
     "D",
 ]
-fixable = [
-    "UP",
-    "I",
-    "D",
-]
-src = [
-    "src",
-    "tests",
-    "examples",
-    "scripts",
-]
-target-version = "py39"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "scripts/*" = [
     "PL",
     "S",
@@ -126,7 +128,7 @@ max-complexity = 10
     "D",
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "pep257"
 
 [tool.mypy]


### PR DESCRIPTION
Recent ruff updates result in a message when running the ruff linters that we need to put specific linter rules under `tools.ruff.lint.xyz` rather than just `tools.ruff.xyz`.