### PR TITLE
Remove obsolete docker hub version

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   app:
     build:

--- a/.github/workflows/check_config_docs.yaml
+++ b/.github/workflows/check_config_docs.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   static-code-analysis:
-    runs-on: ubuntu-latest
-
     name: Check config schema and example
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check_openapi_spec.yaml
+++ b/.github/workflows/check_openapi_spec.yaml
@@ -5,9 +5,9 @@ on: push
 
 jobs:
   static-code-analysis:
-    runs-on: ubuntu-latest
-
     name: Check OpenAPI spec
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check_pyproject.yaml
+++ b/.github/workflows/check_pyproject.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   static-code-analysis:
-    runs-on: ubuntu-latest
-
     name: Check pyproject file
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check_readme.yaml
+++ b/.github/workflows/check_readme.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   static-code-analysis:
-    runs-on: ubuntu-latest
-
     name: Check README file
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check_template_files.yaml
+++ b/.github/workflows/check_template_files.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   check-template-files:
-    runs-on: ubuntu-latest
-
     name: Check template files
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci_release.yaml
+++ b/.github/workflows/ci_release.yaml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   push_to_docker_hub:
+    name: Push to Docker Hub
+
     runs-on: ubuntu-latest
+
     steps:
       - uses: ghga-de/gh-action-ci@v1
         with:

--- a/.github/workflows/ci_workflow_dispatch.yaml
+++ b/.github/workflows/ci_workflow_dispatch.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   fetch-tag:
+    name: Fetch Tag
     runs-on: ubuntu-latest
     if:  github.event_name == 'workflow_dispatch' || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build') ) || ( github.event.action == 'labeled' && github.event.label.name == 'build' )
     steps:
@@ -20,6 +21,7 @@ jobs:
       latest_tag: ${{ steps.fetch-tag.outputs.latest_tag }}
 
   push_to_docker_hub:
+    name: Push to Docker Hub
     needs: fetch-tag
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   static-code-analysis:
-    runs-on: ubuntu-latest
-
     name: Static Code Analysis
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
-
     name: Run test suite
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- Remove obsolete docker hub version to avoid warning in logs
- Use canonical order of properties in GitHub actions