### PR TITLE
Run scripts in GitHub under Python 3.12

### DIFF
--- a/.github/workflows/check_config_docs.yaml
+++ b/.github/workflows/check_config_docs.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v5
+        with:
+          python-version: '3.12'
 
       - name: Check config docs
         id: check-config-docs

--- a/.github/workflows/check_openapi_spec.yaml
+++ b/.github/workflows/check_openapi_spec.yaml
@@ -17,6 +17,8 @@ jobs:
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v5
+        with:
+          python-version: '3.12'
 
       - name: Check openapi.yaml
         id: check-openapi-docs

--- a/.github/workflows/check_pyproject.yaml
+++ b/.github/workflows/check_pyproject.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v5
+        with:
+          python-version: '3.12'
 
       - name: Check pyproject.toml
         id: check-pyproject

--- a/.github/workflows/check_readme.yaml
+++ b/.github/workflows/check_readme.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v5
+        with:
+          python-version: '3.12'
 
       - name: Check README
         id: check-readme

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -16,8 +16,6 @@ jobs:
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v5
-        with:
-          python-version: '3.12'
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v5
+        with:
+          python-version: '3.12'
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Run some of the tools under Python 3.12 on GitHub, because this might be a bit faster.

However, the main static code analysis should run on the same default Python version as locally, which is still Python 3.9. Otherwise there might be some discrepancies between the local and remote analysis, which we want to avoid.