### PR TITLE
Mark removed license checker script as deprecated

### DIFF
--- a/.template/deprecated_files.txt
+++ b/.template/deprecated_files.txt
@@ -13,6 +13,7 @@
 .github/workflows/cd.yaml
 
 scripts/check_mandatory_and_static_files.py
+scripts/license_checker.py
 scripts/update_static_files.py
 
 docs


### PR DESCRIPTION
The script has been renamed to `check_license`, so the old name must be marked as deprecated.