### PR TITLE
Enable default alpine and fallback debian docker image builds (GSI-876)

### DIFF
--- a/.github/workflows/ci_release.yaml
+++ b/.github/workflows/ci_release.yaml
@@ -8,6 +8,10 @@ jobs:
   push_to_docker_hub:
     name: Push to Docker Hub
 
+    strategy:
+      matrix:
+        flavor: ["", "debian"]
+
     runs-on: ubuntu-latest
 
     steps:
@@ -16,3 +20,4 @@ jobs:
           tag: ${{ github.event.release.tag_name }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          flavor: ${{ matrix.flavor }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=builder /service/lock/requirements.txt /service
 RUN pip install --no-deps -r requirements.txt
 
 # RUNNER: a container to run the service
-FROM base as runner
+FROM base AS runner
 WORKDIR /service
 RUN rm -rf /usr/local/lib/python3.12 && mkdir /usr/local/lib/python3.12
 COPY --from=dep-builder /usr/local/lib/python3.12 /usr/local/lib/python3.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk update
 RUN apk upgrade --available
 
 # BUILDER: a container to build the service wheel
-FROM base as builder
+FROM base AS builder
 RUN pip install build
 COPY . /service
 WORKDIR /service

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@
 
 # BASE: a base image with updated packages
 FROM python:3.12-alpine AS base
-RUN apk update
-RUN apk upgrade --available
+RUN apk upgrade --no-cache --available
 
 # BUILDER: a container to build the service wheel
 FROM base AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pip install --no-deps -r requirements.txt
 # RUNNER: a container to run the service
 FROM base AS runner
 WORKDIR /service
-RUN rm -rf /usr/local/lib/python3.12 && mkdir /usr/local/lib/python3.12
+RUN rm -rf /usr/local/lib/python3.12
 COPY --from=dep-builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
 COPY --from=builder /service/dist/ /service
 RUN pip install --no-deps *.whl

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -13,39 +13,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# BASE: a base image with updated packages
-FROM python:3.12-alpine AS base
-RUN apk update
-RUN apk upgrade --available
-
-# BUILDER: a container to build the service wheel
-FROM base as builder
+## creating building container
+FROM python:3.12-slim-bookworm AS builder
+# update and install dependencies
+RUN apt update
+RUN apt upgrade -y
 RUN pip install build
+# copy code
 COPY . /service
 WORKDIR /service
+# build wheel
 RUN python -m build
 
-# DEP-BUILDER: a container to (build and) install dependencies
-FROM base AS dep-builder
-RUN apk update
-RUN apk add build-base gcc g++ libffi-dev zlib-dev
-RUN apk upgrade --available
+# creating running container
+FROM python:3.12-slim-bookworm
+# update and install dependencies
+RUN apt update
+RUN apt upgrade -y
+# copy and install requirements and wheel
 WORKDIR /service
 COPY --from=builder /service/lock/requirements.txt /service
 RUN pip install --no-deps -r requirements.txt
-
-# RUNNER: a container to run the service
-FROM base as runner
-WORKDIR /service
-RUN rm -rf /usr/local/lib/python3.12 && mkdir /usr/local/lib/python3.12
-COPY --from=dep-builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
+RUN rm requirements.txt
 COPY --from=builder /service/dist/ /service
 RUN pip install --no-deps *.whl
 RUN rm *.whl
-RUN adduser -D appuser
+# create new user and execute as that user
+RUN useradd --create-home appuser
 WORKDIR /home/appuser
 USER appuser
+# set environment
 ENV PYTHONUNBUFFERED=1
-
 # Please adapt to package name:
 ENTRYPOINT ["my-microservice"]


### PR DESCRIPTION
This patch changes the template such that it contains two Dockerfiles:

1. `Dockerfile` which builds a runner container based on python-alpine
2. `Dockerfile.debian` which builds a runner container based on python-debian

Both images are pushed to Dockerhub, once with the tag suffix `-debian` once without (this makes use of the recently added support for "flavors" in PR https://github.com/ghga-de/gh-action-ci/pull/4).

The alpine Dockerfile has been tested on all currently deployed services to the extend that they start and fail due to missing configuration.

A separate PR will be opened at https://github.com/ghga-de/file-services-backend.