### PR TITLE
Remove autopep8 vs code extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,8 @@
 				"visualstudioexptteam.vscodeintellicode",
 				"ymotongpoo.licenser",
 				"charliermarsh.ruff",
-				"ms-python.mypy-type-checker"
+				"ms-python.mypy-type-checker",
+				"-ms-python.autopep8"
 			]
 		}
 	},


### PR DESCRIPTION
Used the syntax found [here](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_85.md#opt-out-of-extensions) to remove the autopep8 extension for vs code.

The extension is automatically installed in the devcontainer by a feature included in the base image, and it conflicts with ruff. It's annoying to uninstall autopep8 + reload window every time you rebuild a devcontainer, so this is the solution.