### PR TITLE
Update `requests` version floor

### DIFF
--- a/lock/requirements-dev-template.in
+++ b/lock/requirements-dev-template.in
@@ -20,7 +20,7 @@ httpx>=0.28
 pytest-httpx>=0.35
 
 urllib3>=2.4
-requests>=2.32
+requests>=2.32.4
 
 casefy>=1.1
 jsonschema2md>=1.5

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -753,9 +753,9 @@ referencing==0.36.2 \
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.3 \
-    --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
-    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+requests==2.32.4 \
+    --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
+    --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
     # via
     #   -r lock/requirements-dev-template.in
     #   docker


### PR DESCRIPTION
Saw the dependabot warning for `requests <2.32.4` on the DS Kit, so updating the minimum version req here.