### PR TITLE
Replace debian dockerfile with DHI and update ci release workflow (GSI-2378)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Version control
+.git
+.gitignore
+.gitattributes
+.github
+
+# Dev tooling and IDE
+.devcontainer
+.claude
+.pre-commit-config.yaml
+.pyproject_generation
+.readme_generation
+.template
+
+# Caches
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.coverage
+__pycache__
+*.pyc
+*.pyo
+
+# Build artifacts
+dist
+build
+*.egg-info
+
+# Dev/lock files not needed for production build
+lock/requirements-dev.txt
+lock/requirements-dev.in
+lock/requirements-dev-template.in
+lock/README.md
+
+# Tests and scripts
+tests
+scripts
+
+# Example and runtime config
+example_data
+example_config.yaml
+openapi.yaml
+config_schema.json
+prof

--- a/.github/workflows/ci_release.yaml
+++ b/.github/workflows/ci_release.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        flavor: ["", "debian"]
+        flavor: ["", "dhi"]
 
     runs-on: ubuntu-latest
 

--- a/Dockerfile.dhi
+++ b/Dockerfile.dhi
@@ -13,37 +13,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# creating building container
-FROM python:3.13-slim-trixie AS builder
-# update and install dependencies
-RUN apt-get update && apt-get upgrade -y
+# BASE: a base image with updated packages
+FROM dhi.io/python:3.13-alpine3.23-sfw-dev AS base
+RUN apk upgrade --no-cache --available
+
+# BUILDER: a container to build the service wheel
+FROM base AS builder
 RUN pip install build
-# copy code
 COPY . /service
 WORKDIR /service
-# build wheel
 RUN python -m build
 
-# creating running container
-FROM python:3.13-slim-trixie
-# update and install dependencies
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-# create new user first
-RUN useradd --create-home appuser
-# copy and install requirements and wheel
+# DEP-BUILDER: a container to (build and) install dependencies
+FROM base AS dep-builder
+RUN apk update && \
+    apk add build-base gcc g++ libffi-dev zlib-dev python3-dev && \
+    apk upgrade --available
 WORKDIR /service
 COPY --from=builder /service/lock/requirements.txt /service
-RUN pip install --no-cache-dir --no-deps -r requirements.txt && \
-    rm requirements.txt
+RUN pip install --no-deps -r requirements.txt
 COPY --from=builder /service/dist/ /service
 RUN pip install --no-cache-dir --no-deps *.whl && rm *.whl
-# switch to non-root user
-WORKDIR /home/appuser
-USER appuser
-# set environment
+# Binaries that are needed at runtime
+RUN mkdir -p /opt/runtime-bin
+RUN cp /usr/local/bin/opentelemetry-instrument /opt/runtime-bin/ 2>/dev/null || true
+
+# RUNNER: a container to run the service
+FROM dhi.io/python:3.13-alpine3.23 AS runner
+COPY --from=dep-builder /usr/lib/python3.13 /usr/lib/python3.13
+COPY --from=dep-builder /opt/runtime-bin/ /usr/local/bin/
+
+# Please adapt to package name
+COPY --from=dep-builder /usr/bin/my-microservice /usr/local/bin/my-microservice
+
 ENV PYTHONUNBUFFERED=1
 
 # Please adapt to package name:

--- a/Dockerfile.dhi
+++ b/Dockerfile.dhi
@@ -46,7 +46,8 @@ FROM ${BASE} AS runner
 COPY --from=dep-builder /usr/lib/python3.13 /usr/lib/python3.13
 COPY --from=dep-builder /opt/runtime-bin/ /usr/local/bin/
 
-# USER doesn't have to be manually set because the base image already runs as non-root
+# Base image already runs as non-root (65532), but we use 1000 to be consistent
+USER 1000
 
 # Please adapt to package name
 COPY --from=dep-builder /usr/bin/my-microservice /usr/local/bin/my-microservice

--- a/Dockerfile.dhi
+++ b/Dockerfile.dhi
@@ -13,19 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# BASE: a base image with updated packages
-FROM dhi.io/python:3.13-alpine3.23-sfw-dev AS base
+# Define the non-dev base-image
+ARG BASE=dhi.io/python:3.13-alpine3.23
+
+# BUILDER-BASE: a base image with updated packages using the socket firewall dev variant
+FROM ${BASE}-sfw-dev AS builder-base
 RUN apk upgrade --no-cache --available
 
 # BUILDER: a container to build the service wheel
-FROM base AS builder
+FROM builder-base AS builder
 RUN pip install build
 COPY . /service
 WORKDIR /service
 RUN python -m build
 
 # DEP-BUILDER: a container to (build and) install dependencies
-FROM base AS dep-builder
+FROM builder-base AS dep-builder
 RUN apk update && \
     apk add build-base gcc g++ libffi-dev zlib-dev python3-dev && \
     apk upgrade --available
@@ -39,9 +42,11 @@ RUN mkdir -p /opt/runtime-bin
 RUN cp /usr/local/bin/opentelemetry-instrument /opt/runtime-bin/ 2>/dev/null || true
 
 # RUNNER: a container to run the service
-FROM dhi.io/python:3.13-alpine3.23 AS runner
+FROM ${BASE} AS runner
 COPY --from=dep-builder /usr/lib/python3.13 /usr/lib/python3.13
 COPY --from=dep-builder /opt/runtime-bin/ /usr/local/bin/
+
+# USER doesn't have to be manually set because the base image already runs as non-root
 
 # Please adapt to package name
 COPY --from=dep-builder /usr/bin/my-microservice /usr/local/bin/my-microservice

--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -35,6 +35,7 @@ GLOBAL_COPYRIGHT_FILE_PATH = ROOT_DIR / ".devcontainer" / "license_header.txt"
 EXCLUDE = [
     ".coveragerc",
     ".devcontainer",
+    ".dockerignore",
     ".editorconfig",
     ".eggs",
     ".git",


### PR DESCRIPTION
This replaces the debian runtime Dockerfile with one that uses Docker Hardened Images. The base image used in BUILDER and DEP-BUILDER is a dev-variant with the Socket Firewall (sfw) that scans for known threats in dependencies conveyed in pip commands (or npm, etc.). The RUNNER stage uses the more locked-down non-dev image. 

The old image set the user id to 1000 in order to run as non-root, but these images run with the user ID set to 65532 by default - I left it like that (65532) at the suggestion of Claude and Gordon, but don't know if we have anything in place that would rely on the user ID being 1000.

We need docker credentials during the release job in order to pull the DHI base images (and to publish ours) but pulling our published images shouldn't require authentication.