### PR TITLE
Align and improve Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,36 +19,37 @@ RUN apk upgrade --no-cache --available
 
 # BUILDER: a container to build the service wheel
 FROM base AS builder
-RUN pip install build
+# build backend, intentionally unpinned
+# hadolint ignore=DL3013
+RUN pip install --no-cache-dir build
 COPY . /service
 WORKDIR /service
 RUN python -m build
 
 # DEP-BUILDER: a container to (build and) install dependencies
 FROM base AS dep-builder
-RUN apk update && \
-    apk add build-base gcc g++ libffi-dev zlib-dev && \
-    apk upgrade --available
+# build tools are build-only, intentionally unpinned
+# hadolint ignore=DL3018
+RUN apk add --no-cache build-base gcc g++ libffi-dev zlib-dev && \
+    apk upgrade --no-cache --available
 WORKDIR /service
 COPY --from=builder /service/lock/requirements.txt /service
 RUN pip install --no-cache-dir --no-deps -r requirements.txt
-# Binaries that are needed at runtime
-RUN mkdir -p /opt/runtime-bin
-RUN cp /usr/local/bin/opentelemetry-instrument /opt/runtime-bin/ 2>/dev/null || true
+# Binaries that are needed at runtime (opentelemetry-instrument is optional)
+RUN mkdir -p /opt/runtime-bin \
+ && { cp /usr/local/bin/opentelemetry-instrument /opt/runtime-bin/ 2>/dev/null || true; }
 
 # RUNNER: a container to run the service
 FROM base AS runner
-# create new user first
-RUN adduser -D appuser
+ARG UID=1000
 WORKDIR /service
 RUN rm -rf /usr/local/lib/python3.13
 COPY --from=dep-builder /usr/local/lib/python3.13 /usr/local/lib/python3.13
 COPY --from=dep-builder /opt/runtime-bin/ /usr/local/bin/
 COPY --from=builder /service/dist/ /service
-RUN pip install --no-cache-dir --no-deps *.whl && rm *.whl
-# switch to non-root user
-WORKDIR /home/appuser
-USER appuser
+RUN pip install --no-cache-dir --no-deps ./*.whl && rm ./*.whl
+# switch to non-root user (numeric UID for OpenShift arbitrary-UID compatibility)
+USER ${UID}
 ENV PYTHONUNBUFFERED=1
 
 # Please adapt to package name:

--- a/Dockerfile.dhi
+++ b/Dockerfile.dhi
@@ -17,37 +17,43 @@
 ARG BASE=dhi.io/python:3.13-alpine3.23
 
 # BUILDER-BASE: a base image with updated packages using the socket firewall dev variant
+# hadolint ignore=DL3006
 FROM ${BASE}-sfw-dev AS builder-base
 RUN apk upgrade --no-cache --available
 
 # BUILDER: a container to build the service wheel
 FROM builder-base AS builder
-RUN pip install build
+# build backend, intentionally unpinned
+# hadolint ignore=DL3013
+RUN pip install --no-cache-dir build
 COPY . /service
 WORKDIR /service
 RUN python -m build
 
 # DEP-BUILDER: a container to (build and) install dependencies
 FROM builder-base AS dep-builder
-RUN apk update && \
-    apk add build-base gcc g++ libffi-dev zlib-dev python3-dev && \
-    apk upgrade --available
+# build tools are build-only, intentionally unpinned
+# hadolint ignore=DL3018
+RUN apk add --no-cache build-base gcc g++ libffi-dev zlib-dev python3-dev && \
+    apk upgrade --no-cache --available
 WORKDIR /service
 COPY --from=builder /service/lock/requirements.txt /service
-RUN pip install --no-deps -r requirements.txt
+RUN pip install --no-cache-dir --no-deps -r requirements.txt
 COPY --from=builder /service/dist/ /service
-RUN pip install --no-cache-dir --no-deps *.whl && rm *.whl
-# Binaries that are needed at runtime
-RUN mkdir -p /opt/runtime-bin
-RUN cp /usr/local/bin/opentelemetry-instrument /opt/runtime-bin/ 2>/dev/null || true
+RUN pip install --no-cache-dir --no-deps ./*.whl && rm ./*.whl
+# Binaries that are needed at runtime (opentelemetry-instrument is optional)
+RUN mkdir -p /opt/runtime-bin \
+ && { cp /usr/local/bin/opentelemetry-instrument /opt/runtime-bin/ 2>/dev/null || true; }
 
 # RUNNER: a container to run the service
+# hadolint ignore=DL3006
 FROM ${BASE} AS runner
+ARG UID=1000
 COPY --from=dep-builder /usr/lib/python3.13 /usr/lib/python3.13
 COPY --from=dep-builder /opt/runtime-bin/ /usr/local/bin/
 
 # Base image already runs as non-root (65532), but we use 1000 to be consistent
-USER 1000
+USER ${UID}
 
 # Please adapt to package name
 COPY --from=dep-builder /usr/bin/my-microservice /usr/local/bin/my-microservice


### PR DESCRIPTION
- The standard `Dockerfile` no longer creates a named `appuser`. Both files now use `ARG UID=1000` and switch to the numeric user with `USER ${UID}`.
- Using a numeric UID (rather than a named account) is what platforms that assign an arbitrary UID at runtime — e.g. OpenShift, which also runs with GID 0 — expect. The copied Python libraries and binaries stay root-owned and
  world-readable, so the service starts correctly under UID 1000, an arbitrary UID with GID 0, or a pinned `runAsUser`.
- Dropped the leftover `WORKDIR /home/appuser`; the runner stays in `/service`.
- The UID can be overridden at build time via `--build-arg UID=...`.
- Added `--no-cache-dir` to `pip install` invocations and documented the intentionally unpinned build backend (`DL3013`).
- Replaced `apk update && apk add … && apk upgrade` with `apk add --no-cache … && apk upgrade --no-cache`, matching the base stage style (`DL3019`), and kept the documented ignore for the build-only,
  intentionally unpinned apk packages (`DL3018`). Documented the `DL3006` ignores on the `FROM ${BASE}` stages in
  `Dockerfile.dhi`.
- Quoted wheel globs as `./*.whl` so a dash-leading filename cannot be interpreted as a flag (`SC2035`), and grouped the optional `opentelemetry-instrument` copy so its `|| true` fallback no longer masks a failure of the preceding `mkdir` (`SC2015`).